### PR TITLE
TimeProvider/Clock 기반 공통 시간 유틸 도입

### DIFF
--- a/main-server/src/main/java/com/freedom/common/time/TimeConfig.java
+++ b/main-server/src/main/java/com/freedom/common/time/TimeConfig.java
@@ -1,0 +1,22 @@
+package com.freedom.common.time;
+
+import com.freedom.common.time.infra.SystemTimeProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+@Configuration
+public class TimeConfig {
+
+    @Bean
+    public Clock appClock() {
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+    }
+
+    @Bean
+    public TimeProvider timeProvider(Clock appClock) {
+        return new SystemTimeProvider(appClock);
+    }
+}

--- a/main-server/src/main/java/com/freedom/common/time/TimeProvider.java
+++ b/main-server/src/main/java/com/freedom/common/time/TimeProvider.java
@@ -1,0 +1,21 @@
+package com.freedom.common.time;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public interface TimeProvider {
+
+    // 현재 순간(Instant)
+    Instant instant();
+
+    // 현재 시간(타임존 반영)
+    ZonedDateTime now();
+
+    // 오늘 날짜(로컬 날짜, 타임존 반영)
+    LocalDate today();
+
+    // 애플리케이션 타임존
+    ZoneId zoneId();
+}

--- a/main-server/src/main/java/com/freedom/common/time/infra/SystemTimeProvider.java
+++ b/main-server/src/main/java/com/freedom/common/time/infra/SystemTimeProvider.java
@@ -1,0 +1,36 @@
+package com.freedom.common.time.infra;
+
+import com.freedom.common.time.TimeProvider;
+
+import java.time.*;
+
+public class SystemTimeProvider implements TimeProvider {
+
+    private final Clock clock;
+
+    // Clock을 주입 받는 이유:
+    // 테스트에서 Clock.fixed(...)를 넣어 재현성 확보
+    public SystemTimeProvider(Clock clock) {
+        this.clock = clock;
+    }
+
+    @Override
+    public Instant instant() {
+        return clock.instant();
+    }
+
+    @Override
+    public ZonedDateTime now() {
+        return ZonedDateTime.now(clock);
+    }
+
+    @Override
+    public LocalDate today() {
+        return LocalDate.now(clock);
+    }
+
+    @Override
+    public ZoneId zoneId() {
+        return clock.getZone();
+    }
+}


### PR DESCRIPTION
PR 제목
`TimeProvider` 도입 및 `Clock` 기반 시간 주입(Asia/Seoul)
- - -

추가 이유
- 적금 시뮬레이션에서 날짜 계산의 일관성/테스트 재현성이 필요.
- `LocalDate.now()` 직접 호출 대신 주입 가능한 시간 공급자로 통일.
