### PR TITLE
News API 구현 및 Open AI활용 요약 기능 구현

### DIFF
--- a/main-server/build.gradle
+++ b/main-server/build.gradle
@@ -1,5 +1,4 @@
-\
- plugins {
+plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.4'
 	id 'io.spring.dependency-management' version '1.1.7'
@@ -31,7 +30,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	// implementation 'org.springframework.boot:spring-boot-starter-data-redis' // 나중에 추가
 	
 	// AOP
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
@@ -43,13 +41,22 @@ dependencies {
 
 	// Database
 	runtimeOnly 'com.mysql:mysql-connector-j'
-	
+
+	// AI
+	implementation 'com.openai:openai-java:2.17.0'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+
+	// jackson format xml
+	implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
 	
+	// HTML 파싱
+	implementation 'org.jsoup:jsoup:1.18.1'
+
 	// 테스트
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/main-server/src/main/java/com/freedom/common/config/OpenAIConfig.java
+++ b/main-server/src/main/java/com/freedom/common/config/OpenAIConfig.java
@@ -1,0 +1,20 @@
+package com.freedom.common.config;
+
+import com.openai.client.OpenAIClient;
+import com.openai.client.okhttp.OpenAIOkHttpClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAIConfig {
+    @Value("${openai.api-key}")
+    private String API_KEY;
+
+    @Bean
+    public OpenAIClient openAiConfig() {
+        return OpenAIOkHttpClient.builder()
+                .apiKey(API_KEY)
+                .build();
+    }
+}

--- a/main-server/src/main/java/com/freedom/common/exception/ErrorCode.java
+++ b/main-server/src/main/java/com/freedom/common/exception/ErrorCode.java
@@ -28,8 +28,11 @@ public enum ErrorCode {
     DUPLICATE_EMAIL("USER002", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),
     INVALID_PASSWORD("USER003", "비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
     USER_WITHDRAWN("USER004", "탈퇴한 사용자입니다.", HttpStatus.FORBIDDEN),
-    USER_SUSPENDED("USER005", "정지된 사용자입니다.", HttpStatus.FORBIDDEN);
-    
+    USER_SUSPENDED("USER005", "정지된 사용자입니다.", HttpStatus.FORBIDDEN),
+
+    // 뉴스 에러
+    NEWS_NOT_FOUND("NEWS001", "뉴스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
     private final String code;
     private final String message;
     private final HttpStatus status;

--- a/main-server/src/main/java/com/freedom/common/exception/GlobalExceptionHandler.java
+++ b/main-server/src/main/java/com/freedom/common/exception/GlobalExceptionHandler.java
@@ -24,6 +24,12 @@ public class GlobalExceptionHandler {
         log.warn("사용자를 찾을 수 없음: {}", e.getMessage());
         return createErrorResponse(ErrorCode.USER_NOT_FOUND);
     }
+
+    @ExceptionHandler(NewsNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNewsNotFoundException(NewsNotFoundException e) {
+        log.warn("뉴스를 찾을 수 없음: {}", e.getMessage());
+        return createErrorResponse(ErrorCode.NEWS_NOT_FOUND);
+    }
     
     @ExceptionHandler(DuplicateEmailException.class)
     public ResponseEntity<ErrorResponse> handleDuplicateEmailException(DuplicateEmailException e) {

--- a/main-server/src/main/java/com/freedom/common/exception/custom/NewsNotFoundException.java
+++ b/main-server/src/main/java/com/freedom/common/exception/custom/NewsNotFoundException.java
@@ -1,0 +1,7 @@
+package com.freedom.common.exception.custom;
+
+public class NewsNotFoundException extends RuntimeException {
+  public NewsNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/main-server/src/main/java/com/freedom/common/notification/DiscordWebhookClient.java
+++ b/main-server/src/main/java/com/freedom/common/notification/DiscordWebhookClient.java
@@ -1,0 +1,65 @@
+package com.freedom.common.notification;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DiscordWebhookClient {
+
+    private final WebClient webClient = WebClient.create();
+
+    @Value("${discord.webhook-url}")
+    private String webhookUrl;
+
+    public void sendErrorMessage(String title, String errorMessage) {
+        if (!isWebhookEnabled()) {
+            return;
+        }
+
+        try {
+            Map<String, Object> embed = createEmbed(title, errorMessage, "15158332"); // 빨간색
+            sendToDiscord(embed);
+
+        } catch (Exception e) {
+            log.error("디스코드 오류 알림 전송 실패", e);
+        }
+    }
+
+    private Map<String, Object> createEmbed(String title, String description, String color) {
+        return Map.of(
+                "title", title,
+                "description", description,
+                "color", Integer.parseInt(color),
+                "timestamp", LocalDateTime.now().toString()
+        );
+    }
+
+    private void sendToDiscord(Map<String, Object> embed) {
+        Map<String, Object> payload = Map.of("embeds", List.of(embed));
+
+        webClient.post()
+                .uri(webhookUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(payload)
+                .retrieve()
+                .bodyToMono(String.class)
+                .timeout(Duration.ofSeconds(10))
+                .block();
+    }
+
+    private boolean isWebhookEnabled() {
+        return StringUtils.hasText(webhookUrl) && !webhookUrl.contains("${");
+    }
+}

--- a/main-server/src/main/java/com/freedom/common/util/HashUtil.java
+++ b/main-server/src/main/java/com/freedom/common/util/HashUtil.java
@@ -1,0 +1,29 @@
+package com.freedom.common.util;
+
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public final class HashUtil {
+
+    private HashUtil() {}
+
+    public static String sha256(String input) {
+        if (input == null) input = "";
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+
+            StringBuilder hex = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                String h = Integer.toHexString(0xff & b);
+                if (h.length() == 1) hex.append('0');
+                hex.append(h);
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 not supported", e);
+        }
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/api/NewsController.java
+++ b/main-server/src/main/java/com/freedom/news/api/NewsController.java
@@ -1,0 +1,37 @@
+package com.freedom.news.api;
+
+import com.freedom.news.api.response.NewsDetailResponse;
+import com.freedom.news.api.response.NewsResponse;
+import com.freedom.news.application.facade.NewsQueryAppService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/news")
+@RequiredArgsConstructor
+public class NewsController {
+
+    private final NewsQueryAppService newsQueryFacade;
+
+    @GetMapping
+    public ResponseEntity<Page<NewsResponse>> getNewsList(@RequestParam(defaultValue = "0") int page,
+                                                          @RequestParam(defaultValue = "10") int size) {
+        Page<NewsResponse> newsList = newsQueryFacade.getRecentNewsList(page, size);
+        return ResponseEntity.ok(newsList);
+    }
+
+    @GetMapping("/{newsId}")
+    public ResponseEntity<NewsDetailResponse> getNewsDetail(@PathVariable Long newsId) {
+        NewsDetailResponse newsDetail = newsQueryFacade.getNewsDetail(newsId);
+        return ResponseEntity.ok(newsDetail);
+    }
+
+    @PostMapping("/{newsId}/scrap")
+    public ResponseEntity<Void> scrapNews(@PathVariable Long newsId) {
+        // TODO: newsService.scrapNews(newsId) 구현 필요
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/api/response/NewsContentBlockResponse.java
+++ b/main-server/src/main/java/com/freedom/news/api/response/NewsContentBlockResponse.java
@@ -1,0 +1,30 @@
+package com.freedom.news.api.response;
+
+import com.freedom.news.application.dto.NewsContentBlockDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class NewsContentBlockResponse {
+    
+    private String blockType;
+    private String originalContent;
+    private String plainContent;
+    private String url;
+    private String altText;
+    private Integer blockOrder;
+    
+    public static NewsContentBlockResponse from(NewsContentBlockDto dto) {
+        return NewsContentBlockResponse.builder()
+                .blockType(dto.getBlockType())
+                .originalContent(dto.getOriginalContent())
+                .plainContent(dto.getPlainContent())
+                .url(dto.getUrl())
+                .altText(dto.getAltText())
+                .blockOrder(dto.getBlockOrder())
+                .build();
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/api/response/NewsDetailResponse.java
+++ b/main-server/src/main/java/com/freedom/news/api/response/NewsDetailResponse.java
@@ -1,0 +1,42 @@
+package com.freedom.news.api.response;
+
+import com.freedom.news.application.dto.NewsDetailDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class NewsDetailResponse {
+    
+    private Long id;
+    private String newsItemId;
+    private String title;
+    private LocalDateTime approveDate;
+    private LocalDateTime modifyDate;
+    private String thumbnailUrl;
+    private String aiSummary;
+    private String plainTextContent;
+    private List<NewsContentBlockResponse> contentBlocks;
+    
+    public static NewsDetailResponse from(NewsDetailDto newsDetailDto) {
+        return NewsDetailResponse.builder()
+                .id(newsDetailDto.getId())
+                .newsItemId(newsDetailDto.getNewsItemId())
+                .title(newsDetailDto.getTitle())
+                .approveDate(newsDetailDto.getApproveDate())
+                .modifyDate(newsDetailDto.getModifyDate())
+                .thumbnailUrl(newsDetailDto.getThumbnailUrl())
+                .aiSummary(newsDetailDto.getAiSummary())
+                .plainTextContent(newsDetailDto.getPlainTextContent())
+                .contentBlocks(newsDetailDto.getContentBlocks()
+                        .stream()
+                        .map(NewsContentBlockResponse::from)
+                        .toList())
+                .build();
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/api/response/NewsResponse.java
+++ b/main-server/src/main/java/com/freedom/news/api/response/NewsResponse.java
@@ -1,0 +1,42 @@
+package com.freedom.news.api.response;
+
+import com.freedom.news.application.dto.NewsDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class NewsResponse {
+    
+    private Long id;
+    private String newsItemId;
+    private String title;
+    private String subTitle1;
+    private String subTitle2;
+    private String subTitle3;
+    private LocalDateTime approveDate;
+    private LocalDateTime modifyDate;
+    private String thumbnailUrl;
+    private String aiSummary;
+    private String plainTextContent;
+    
+    public static NewsResponse from(NewsDto newsDto) {
+        return NewsResponse.builder()
+                .id(newsDto.getId())
+                .newsItemId(newsDto.getNewsItemId())
+                .title(newsDto.getTitle())
+                .subTitle1(newsDto.getSubTitle1())
+                .subTitle2(newsDto.getSubTitle2())
+                .subTitle3(newsDto.getSubTitle3())
+                .approveDate(newsDto.getApproveDate())
+                .modifyDate(newsDto.getModifyDate())
+                .thumbnailUrl(newsDto.getThumbnailUrl())
+                .aiSummary(newsDto.getAiSummary())
+                .plainTextContent(newsDto.getPlainTextContent())
+                .build();
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/application/dto/ExistingNewsDto.java
+++ b/main-server/src/main/java/com/freedom/news/application/dto/ExistingNewsDto.java
@@ -1,0 +1,17 @@
+package com.freedom.news.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ExistingNewsDto {
+
+    private String newsItemId;
+    private Integer modifyId;
+    private String contentHash;
+    
+    public static ExistingNewsDto of(String newsItemId, Integer modifyId, String contentHash) {
+        return new ExistingNewsDto(newsItemId, modifyId, contentHash);
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/application/dto/NewsArticleDto.java
+++ b/main-server/src/main/java/com/freedom/news/application/dto/NewsArticleDto.java
@@ -1,0 +1,146 @@
+package com.freedom.news.application.dto;
+
+import com.freedom.common.util.HashUtil;
+import com.freedom.news.domain.model.ProcessedBlock;
+import com.freedom.news.domain.model.ProcessedNews;
+import com.freedom.news.domain.entity.NewsArticle;
+import com.freedom.news.domain.entity.NewsContentBlock;
+import com.freedom.news.infra.client.response.NewsItem;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Getter
+@Builder
+public class NewsArticleDto {
+    
+    private String newsItemId;
+    private String contentsStatus;
+    private Integer modifyId;
+    private LocalDateTime modifyDate;
+    private LocalDateTime approveDate;
+    private String approverName;
+    private LocalDateTime embargoDate;
+    private String groupingCode;
+    private String title;
+    private String subTitle1;
+    private String subTitle2;
+    private String subTitle3;
+    private String contentsType;
+    private String dataContents;
+    private String plainTextContent;
+    private String ministerCode;
+    private String thumbnailUrl;
+    private String originalImgUrl;
+    private String originalUrl;
+    private List<ProcessedBlock> processedBlocks;
+    private String aiSummary;
+
+    public static NewsArticleDto from(NewsItem newsItem, ProcessedNews processedNews) {
+        return NewsArticleDto.builder()
+                .newsItemId(newsItem.getNewsItemId())
+                .contentsStatus(newsItem.getContentsStatus())
+                .modifyId(newsItem.getModifyId())
+                .modifyDate(parseDateTime(newsItem.getModifyDate()))
+                .approveDate(parseDateTime(newsItem.getApproveDate()))
+                .approverName(newsItem.getApproverName())
+                .embargoDate(parseDateTime(newsItem.getEmbargoDate()))
+                .groupingCode(newsItem.getGroupingCode())
+                .title(newsItem.getTitle())
+                .subTitle1(newsItem.getSubTitle1())
+                .subTitle2(newsItem.getSubTitle2())
+                .subTitle3(newsItem.getSubTitle3())
+                .contentsType(newsItem.getContentsType())
+                .dataContents(newsItem.getDataContents())
+                .plainTextContent(processedNews.getEntirePlainText())
+                .ministerCode(newsItem.getMinisterCode())
+                .thumbnailUrl(newsItem.getThumbnailUrl())
+                .originalImgUrl(newsItem.getOriginalImgUrl())
+                .originalUrl(newsItem.getOriginalUrl())
+                .processedBlocks(processedNews.getProcessedBlocks())
+                .aiSummary(null)
+                .build();
+    }
+    
+    private static LocalDateTime parseDateTime(String dateTimeString) {
+        if (dateTimeString == null || dateTimeString.trim().isEmpty()) {
+            return null;
+        }
+        
+        try {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy HH:mm:ss");
+            return LocalDateTime.parse(dateTimeString, formatter);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+    
+    public NewsArticleDto withAiSummary(String aiSummary) {
+        return NewsArticleDto.builder()
+                .newsItemId(this.newsItemId)
+                .contentsStatus(this.contentsStatus)
+                .modifyId(this.modifyId)
+                .modifyDate(this.modifyDate)
+                .approveDate(this.approveDate)
+                .approverName(this.approverName)
+                .embargoDate(this.embargoDate)
+                .groupingCode(this.groupingCode)
+                .title(this.title)
+                .subTitle1(this.subTitle1)
+                .subTitle2(this.subTitle2)
+                .subTitle3(this.subTitle3)
+                .contentsType(this.contentsType)
+                .dataContents(this.dataContents)
+                .plainTextContent(this.plainTextContent)
+                .ministerCode(this.ministerCode)
+                .thumbnailUrl(this.thumbnailUrl)
+                .originalImgUrl(this.originalImgUrl)
+                .originalUrl(this.originalUrl)
+                .processedBlocks(this.processedBlocks)
+                .aiSummary(aiSummary)
+                .build();
+    }
+    
+    public NewsArticle toEntity() {
+        NewsArticle article = NewsArticle.builder()
+                .newsItemId(this.newsItemId)
+                .contentsStatus(this.contentsStatus)
+                .modifyId(this.modifyId)
+                .modifyDate(this.modifyDate)
+                .approveDate(this.approveDate)
+                .approverName(this.approverName)
+                .embargoDate(this.embargoDate)
+                .groupingCode(this.groupingCode)
+                .title(this.title)
+                .subTitle1(this.subTitle1)
+                .subTitle2(this.subTitle2)
+                .subTitle3(this.subTitle3)
+                .contentsType(this.contentsType)
+                .dataContents(this.dataContents)
+                .plainTextContent(this.plainTextContent)
+                .contentHash(generateContentHash())
+                .ministerCode(this.ministerCode)
+                .thumbnailUrl(this.thumbnailUrl)
+                .originalImgUrl(this.originalImgUrl)
+                .originalUrl(this.originalUrl)
+                .aiSummary(this.aiSummary)
+                .build();
+
+        if (this.processedBlocks != null && !this.processedBlocks.isEmpty()) {
+            int order = 1;
+            for (ProcessedBlock block : this.processedBlocks) {
+                NewsContentBlock entityBlock = NewsContentBlock.from(block, article, order++);
+                article.getContentBlocks().add(entityBlock);
+            }
+        }
+
+        return article;
+    }
+
+    public String generateContentHash() {
+        return HashUtil.sha256(this.dataContents != null ? this.dataContents : "");
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/application/dto/NewsContentBlockDto.java
+++ b/main-server/src/main/java/com/freedom/news/application/dto/NewsContentBlockDto.java
@@ -1,0 +1,30 @@
+package com.freedom.news.application.dto;
+
+import com.freedom.news.domain.entity.NewsContentBlock;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class NewsContentBlockDto {
+    
+    private String blockType;
+    private String originalContent;
+    private String plainContent;
+    private String url;
+    private String altText;
+    private Integer blockOrder;
+    
+    public static NewsContentBlockDto from(NewsContentBlock contentBlock) {
+        return NewsContentBlockDto.builder()
+                .blockType(contentBlock.getBlockType())
+                .originalContent(contentBlock.getOriginalContent())
+                .plainContent(contentBlock.getPlainContent())
+                .url(contentBlock.getUrl())
+                .altText(contentBlock.getAltText())
+                .blockOrder(contentBlock.getBlockOrder())
+                .build();
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/application/dto/NewsDetailDto.java
+++ b/main-server/src/main/java/com/freedom/news/application/dto/NewsDetailDto.java
@@ -1,0 +1,45 @@
+package com.freedom.news.application.dto;
+
+import com.freedom.news.domain.entity.NewsArticle;
+import com.freedom.news.domain.entity.NewsContentBlock;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class NewsDetailDto {
+
+    private Long id;
+    private String newsItemId;
+    private String title;
+    private LocalDateTime approveDate;
+    private LocalDateTime modifyDate;
+    private String thumbnailUrl;
+    private String aiSummary;
+    private String plainTextContent;
+    private List<NewsContentBlockDto> contentBlocks;
+
+    public static NewsDetailDto from(NewsArticle newsArticle, List<NewsContentBlock> contentBlocks) {
+        List<NewsContentBlockDto> contentBlockDtos = contentBlocks
+                .stream()
+                .map(NewsContentBlockDto::from)
+                .toList();
+
+        return NewsDetailDto.builder()
+                .id(newsArticle.getId())
+                .newsItemId(newsArticle.getNewsItemId())
+                .title(newsArticle.getTitle())
+                .approveDate(newsArticle.getApproveDate())
+                .modifyDate(newsArticle.getModifyDate())
+                .thumbnailUrl(newsArticle.getThumbnailUrl())
+                .aiSummary(newsArticle.getAiSummary())
+                .plainTextContent(newsArticle.getPlainTextContent())
+                .contentBlocks(contentBlockDtos)
+                .build();
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/application/dto/NewsDto.java
+++ b/main-server/src/main/java/com/freedom/news/application/dto/NewsDto.java
@@ -1,0 +1,42 @@
+package com.freedom.news.application.dto;
+
+import com.freedom.news.domain.entity.NewsArticle;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class NewsDto {
+    
+    private Long id;
+    private String newsItemId;
+    private String title;
+    private String subTitle1;
+    private String subTitle2;
+    private String subTitle3;
+    private LocalDateTime approveDate;
+    private LocalDateTime modifyDate;
+    private String thumbnailUrl;
+    private String aiSummary;
+    private String plainTextContent;
+    
+    public static NewsDto from(NewsArticle newsArticle) {
+        return NewsDto.builder()
+                .id(newsArticle.getId())
+                .newsItemId(newsArticle.getNewsItemId())
+                .title(newsArticle.getTitle())
+                .subTitle1(newsArticle.getSubTitle1())
+                .subTitle2(newsArticle.getSubTitle2())
+                .subTitle3(newsArticle.getSubTitle3())
+                .approveDate(newsArticle.getApproveDate())
+                .modifyDate(newsArticle.getModifyDate())
+                .thumbnailUrl(newsArticle.getThumbnailUrl())
+                .aiSummary(newsArticle.getAiSummary())
+                .plainTextContent(newsArticle.getPlainTextContent())
+                .build();
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/application/facade/NewsFacade.java
+++ b/main-server/src/main/java/com/freedom/news/application/facade/NewsFacade.java
@@ -1,0 +1,80 @@
+package com.freedom.news.application.facade;
+
+import com.freedom.news.application.dto.NewsArticleDto;
+import com.freedom.news.domain.result.NewsClassificationResult;
+import com.freedom.news.domain.model.ProcessedNews;
+import com.freedom.news.domain.service.NewsContentProcessingService;
+import com.freedom.news.domain.service.NewsExistingCheckService;
+import com.freedom.news.domain.service.NewsPersistenceService;
+import com.freedom.news.infra.client.OpenAiNewsSummaryClient;
+import com.freedom.news.infra.client.PolicyNewsClient;
+import com.freedom.news.infra.client.response.NewsItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class NewsFacade {
+
+    private final PolicyNewsClient policyNewsClient;
+    private final NewsContentProcessingService newsContentProcessingService;
+    private final NewsExistingCheckService newsExistingCheckService;
+    private final OpenAiNewsSummaryClient openAiNewsSummaryClient;
+    private final NewsPersistenceService newsPersistenceService;
+
+    @Transactional
+    public void newsCollection() {
+        List<NewsItem> newsList = policyNewsClient.getNewsAPI();
+        if (newsList.isEmpty()) return;
+
+        NewsClassificationResult classification = newsExistingCheckService.classifyNews(newsList);
+        if (!classification.hasNewsToProcess()) return;
+
+        List<NewsArticleDto> newArticles    = toArticlesDistinctById(classification.getNewNews());
+        List<NewsArticleDto> updatedArticles = toArticlesDistinctById(classification.getUpdatedNews());
+
+        List<NewsArticleDto> summarizedNew     = summarizeAll(newArticles);
+        List<NewsArticleDto> summarizedUpdated = summarizeAll(updatedArticles);
+
+        if (!summarizedNew.isEmpty()) {
+            newsPersistenceService.saveNewArticles(summarizedNew);
+        }
+        if (!summarizedUpdated.isEmpty()) {
+            newsPersistenceService.updateArticles(summarizedUpdated);
+        }
+    }
+
+    private List<NewsArticleDto> toArticlesDistinctById(List<NewsItem> items) {
+        if (items == null || items.isEmpty()) return List.of();
+
+        Map<String, NewsItem> dedup = items.stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(
+                        NewsItem::getNewsItemId,
+                        Function.identity(),
+                        (a, b) -> a,
+                        LinkedHashMap::new
+                ));
+
+        return dedup.values().stream()
+                .map(this::processNewsItem)
+                .toList();
+    }
+
+    private List<NewsArticleDto> summarizeAll(List<NewsArticleDto> articles) {
+        if (articles == null || articles.isEmpty()) return List.of();
+        return articles.stream()
+                .map(a -> a.withAiSummary(openAiNewsSummaryClient.summarize(a.getPlainTextContent())))
+                .toList();
+    }
+
+    private NewsArticleDto processNewsItem(NewsItem newsItem) {
+        ProcessedNews processedNews = newsContentProcessingService.processHtmlContent(newsItem.getDataContents());
+        return NewsArticleDto.from(newsItem, processedNews);
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/application/facade/NewsQueryAppService.java
+++ b/main-server/src/main/java/com/freedom/news/application/facade/NewsQueryAppService.java
@@ -1,0 +1,32 @@
+package com.freedom.news.application.facade;
+
+import com.freedom.news.api.response.NewsDetailResponse;
+import com.freedom.news.api.response.NewsResponse;
+import com.freedom.news.application.dto.NewsDetailDto;
+import com.freedom.news.application.dto.NewsDto;
+import com.freedom.news.domain.service.FindNewsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NewsQueryAppService {
+    
+    private final FindNewsService findNewsService;
+    
+    public Page<NewsResponse> getRecentNewsList(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<NewsDto> newsDtos = findNewsService.findRecentNews(pageable);
+        
+        return newsDtos.map(NewsResponse::from);
+    }
+
+    public NewsDetailResponse getNewsDetail(Long newsId) {
+        NewsDetailDto newsDetailDto = findNewsService.findNewsById(newsId);
+        
+        return NewsDetailResponse.from(newsDetailDto);
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/application/schedule/NewsScheduler.java
+++ b/main-server/src/main/java/com/freedom/news/application/schedule/NewsScheduler.java
@@ -1,0 +1,44 @@
+package com.freedom.news.application.schedule;
+
+import com.freedom.common.logging.Loggable;
+import com.freedom.news.application.facade.NewsFacade;
+import com.freedom.common.notification.DiscordWebhookClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+@Component
+@RequiredArgsConstructor
+public class NewsScheduler {
+    
+    private final NewsFacade newsFacade;
+    private final DiscordWebhookClient discordWebhookClient;
+    
+    @Scheduled(cron = "${news.scheduler.cron}")
+    @Loggable("뉴스 수집 스케줄러")
+    public void scheduleNewsCollection() {
+        try {
+            newsFacade.newsCollection();
+        } catch (Exception e) {
+            String stackTrace = getStackTraceAsString(e);
+
+            discordWebhookClient.sendErrorMessage(
+                    "🚨 뉴스 수집 스케줄러 오류",
+                    "**오류 메시지:** " + e.getMessage() + 
+                    "\n\n**스택 트레이스:**\n```" + 
+                    (stackTrace.length() > 1500 ? stackTrace.substring(0, 1500) + "..." : stackTrace) + 
+                    "```"
+            );
+        }
+    }
+    
+    private String getStackTraceAsString(Exception e) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        e.printStackTrace(pw);
+        return sw.toString();
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/domain/entity/NewsArticle.java
+++ b/main-server/src/main/java/com/freedom/news/domain/entity/NewsArticle.java
@@ -1,0 +1,146 @@
+package com.freedom.news.domain.entity;
+
+import com.freedom.common.entity.BaseEntity;
+import com.freedom.news.application.dto.NewsArticleDto;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "news_article")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NewsArticle extends BaseEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "news_item_id", length = 10, unique = true, nullable = false)
+    private String newsItemId;
+    
+    @Column(name = "contents_status", length = 1, nullable = false)
+    private String contentsStatus;
+    
+    @Column(name = "modify_id")
+    private Integer modifyId;
+    
+    @Column(name = "modify_date")
+    private LocalDateTime modifyDate;
+    
+    @Column(name = "approve_date")
+    private LocalDateTime approveDate;
+    
+    @Column(name = "approver_name", length = 50)
+    private String approverName;
+    
+    @Column(name = "embargo_date")
+    private LocalDateTime embargoDate;
+    
+    @Column(name = "grouping_code", length = 20)
+    private String groupingCode;
+    
+    @Column(name = "title", length = 400, nullable = false)
+    private String title;
+    
+    @Column(name = "sub_title1", length = 200)
+    private String subTitle1;
+    
+    @Column(name = "sub_title2", length = 200)  
+    private String subTitle2;
+    
+    @Column(name = "sub_title3", length = 200)
+    private String subTitle3;
+    
+    @Column(name = "contents_type", length = 1, nullable = false)
+    private String contentsType;
+    
+    @Column(name = "data_contents", columnDefinition = "TEXT")
+    private String dataContents;
+    
+    @Column(name = "plain_text_content", columnDefinition = "TEXT")
+    private String plainTextContent;
+    
+    @Column(name = "content_hash", length = 64)
+    private String contentHash;
+
+    @Column(name = "minister_code", length = 20)
+    private String ministerCode;
+    
+    @Column(name = "thumbnail_url", length = 500)
+    private String thumbnailUrl;
+    
+    @Column(name = "original_img_url", length = 1000)
+    private String originalImgUrl;
+    
+    @Column(name = "original_url", length = 1000)
+    private String originalUrl;
+    
+    @Column(name = "ai_summary", length = 500)
+    private String aiSummary;
+    
+    @OneToMany(mappedBy = "newsArticle", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OrderBy("blockOrder ASC")
+    private List<NewsContentBlock> contentBlocks = new ArrayList<>();
+    
+    @Builder
+    public NewsArticle(String newsItemId, String contentsStatus, Integer modifyId, 
+                      LocalDateTime modifyDate, LocalDateTime approveDate, String approverName,
+                      LocalDateTime embargoDate, String groupingCode, String title,
+                      String subTitle1, String subTitle2, String subTitle3,
+                      String contentsType, String dataContents, String plainTextContent,
+                      String contentHash, String ministerCode, String thumbnailUrl,
+                      String originalImgUrl, String originalUrl, String aiSummary) {
+        this.newsItemId = newsItemId;
+        this.contentsStatus = contentsStatus != null ? contentsStatus : "U";
+        this.modifyId = modifyId != null ? modifyId : 1;
+        this.modifyDate = modifyDate;
+        this.approveDate = approveDate;
+        this.approverName = approverName;
+        this.embargoDate = embargoDate;
+        this.groupingCode = groupingCode;
+        this.title = title;
+        this.subTitle1 = subTitle1;
+        this.subTitle2 = subTitle2;
+        this.subTitle3 = subTitle3;
+        this.contentsType = contentsType;
+        this.dataContents = dataContents;
+        this.plainTextContent = plainTextContent;
+        this.contentHash = contentHash;
+        this.ministerCode = ministerCode;
+        this.thumbnailUrl = thumbnailUrl;
+        this.originalImgUrl = originalImgUrl;
+        this.originalUrl = originalUrl;
+        this.aiSummary = aiSummary;
+    }
+
+    public void updateFromDto(NewsArticleDto dto) {
+        this.newsItemId = dto.getNewsItemId();
+        this.contentsStatus = dto.getContentsStatus();
+        this.modifyId = dto.getModifyId();
+        this.modifyDate = dto.getModifyDate();
+        this.approveDate = dto.getApproveDate();
+        this.approverName = dto.getApproverName();
+        this.embargoDate = dto.getEmbargoDate();
+        this.groupingCode = dto.getGroupingCode();
+        this.title = dto.getTitle();
+        this.subTitle1 = dto.getSubTitle1();
+        this.subTitle2 = dto.getSubTitle2();
+        this.subTitle3 = dto.getSubTitle3();
+        this.contentsType = dto.getContentsType();
+        this.dataContents = dto.getDataContents();
+        this.plainTextContent = dto.getPlainTextContent();
+        this.contentHash = dto.generateContentHash();
+        this.ministerCode = dto.getMinisterCode();
+        this.thumbnailUrl = dto.getThumbnailUrl();
+        this.originalImgUrl = dto.getOriginalImgUrl();
+        this.originalUrl = dto.getOriginalUrl();
+        this.aiSummary = dto.getAiSummary();
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/domain/entity/NewsContentBlock.java
+++ b/main-server/src/main/java/com/freedom/news/domain/entity/NewsContentBlock.java
@@ -1,0 +1,71 @@
+package com.freedom.news.domain.entity;
+
+import com.freedom.common.entity.BaseEntity;
+import com.freedom.news.domain.model.ProcessedBlock;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "news_content_block")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NewsContentBlock extends BaseEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_article_id")
+    private NewsArticle newsArticle;
+    
+    @Column(name = "news_article_id", nullable = false, insertable = false, updatable = false)
+    private Long newsArticleId;
+    
+    @Column(name = "block_order", nullable = false)
+    private Integer blockOrder;
+    
+    @Column(name = "block_type", length = 20, nullable = false)
+    private String blockType;
+    
+    @Column(name = "original_content", columnDefinition = "TEXT")
+    private String originalContent;
+    
+    @Column(name = "plain_content", columnDefinition = "TEXT")
+    private String plainContent;
+    
+    @Column(name = "url", length = 1000)
+    private String url;
+    
+    @Column(name = "alt_text", length = 500)
+    private String altText;
+    
+    @Builder
+    public NewsContentBlock(NewsArticle newsArticle, Long newsArticleId, Integer blockOrder, String blockType, 
+                           String originalContent, String plainContent, String url, String altText) {
+        this.newsArticle = newsArticle;
+        this.newsArticleId = newsArticleId;
+        this.blockOrder = blockOrder;
+        this.blockType = blockType;
+        this.originalContent = originalContent;
+        this.plainContent = plainContent;
+        this.url = url;
+        this.altText = altText;
+    }
+    
+    public static NewsContentBlock from(ProcessedBlock processedBlock, NewsArticle newsArticle, Integer blockOrder) {
+        return NewsContentBlock.builder()
+                .newsArticle(newsArticle)
+                .newsArticleId(newsArticle.getId())
+                .blockOrder(blockOrder)
+                .blockType(processedBlock.getType())
+                .originalContent(processedBlock.getOriginalContent())
+                .plainContent(processedBlock.getPlainContent())
+                .url(processedBlock.getUrl())
+                .altText(processedBlock.getAlt())
+                .build();
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/domain/model/ProcessedBlock.java
+++ b/main-server/src/main/java/com/freedom/news/domain/model/ProcessedBlock.java
@@ -1,0 +1,46 @@
+package com.freedom.news.domain.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Builder
+public class ProcessedBlock {
+
+    private String type;
+    private String originalContent;
+    private String plainContent;
+    private String url;
+    private String alt;
+    
+    public static ProcessedBlock text(String originalContent, String plainContent) {
+        return ProcessedBlock.builder()
+                .type("text")
+                .originalContent(originalContent)
+                .plainContent(plainContent)
+                .build();
+    }
+
+    public static ProcessedBlock heading(String originalContent, String plainContent, int level) {
+        return ProcessedBlock.builder()
+                .type("heading_" + level)
+                .originalContent(originalContent)
+                .plainContent(plainContent)
+                .build();
+    }
+    
+    public static ProcessedBlock image(String url, String alt) {
+        return ProcessedBlock.builder()
+                .type("image")
+                .url(url)
+                .alt(alt)
+                .build();
+    }
+
+    public static ProcessedBlock paragraphBreak() {
+        return ProcessedBlock.builder()
+                .type("paragraph_break")
+                .build();
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/domain/model/ProcessedNews.java
+++ b/main-server/src/main/java/com/freedom/news/domain/model/ProcessedNews.java
@@ -1,0 +1,21 @@
+package com.freedom.news.domain.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ProcessedNews {
+
+    private List<ProcessedBlock> processedBlocks;
+    private String entirePlainText;
+
+    public static ProcessedNews of(List<ProcessedBlock> processedBlocks, String entirePlainText) {
+        return ProcessedNews.builder()
+                .processedBlocks(processedBlocks)
+                .entirePlainText(entirePlainText)
+                .build();
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/domain/result/NewsClassificationResult.java
+++ b/main-server/src/main/java/com/freedom/news/domain/result/NewsClassificationResult.java
@@ -1,0 +1,26 @@
+package com.freedom.news.domain.result;
+
+import com.freedom.news.infra.client.response.NewsItem;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class NewsClassificationResult {
+    
+    private final List<NewsItem> newNews;
+    private final List<NewsItem> updatedNews;
+    
+    public static NewsClassificationResult of(List<NewsItem> newNews, List<NewsItem> updatedNews) {
+        return NewsClassificationResult.builder()
+                .newNews(newNews)
+                .updatedNews(updatedNews)
+                .build();
+    }
+    
+    public boolean hasNewsToProcess() {
+        return !newNews.isEmpty() || !updatedNews.isEmpty();
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/domain/service/FindNewsService.java
+++ b/main-server/src/main/java/com/freedom/news/domain/service/FindNewsService.java
@@ -1,0 +1,53 @@
+package com.freedom.news.domain.service;
+
+import com.freedom.common.exception.custom.NewsNotFoundException;
+import com.freedom.news.application.dto.NewsDetailDto;
+import com.freedom.news.application.dto.NewsDto;
+import com.freedom.news.domain.entity.NewsArticle;
+import com.freedom.news.infra.repository.NewsArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class FindNewsService {
+    
+    private final NewsArticleRepository newsArticleRepository;
+
+    @Transactional(readOnly = true)
+    public Page<NewsDto> findRecentNews(Pageable pageable) {
+        LocalDate today = LocalDate.now();
+        LocalDateTime startDate;
+        LocalDateTime endDate;
+        
+        // 토요일(6) 또는 일요일(7)인 경우
+        if (today.getDayOfWeek().getValue() >= 6) {
+            LocalDate monday = today.with(java.time.DayOfWeek.MONDAY);
+            LocalDate friday = today.with(java.time.DayOfWeek.FRIDAY);
+            startDate = monday.atStartOfDay();
+            endDate   = friday.plusDays(1).atStartOfDay();
+        } else {
+            // 평일: 어제 00:00 ~ 내일 00:00  ➜ 어제+오늘 포함
+            startDate = today.minusDays(1).atStartOfDay();
+            endDate   = today.plusDays(1).atStartOfDay();
+        }
+        
+        Page<NewsArticle> newsArticles = newsArticleRepository.findRecentNewsByApproveDateBetween(
+            startDate, endDate, pageable
+        );
+        
+        return newsArticles.map(NewsDto::from);
+    }
+
+    @Transactional(readOnly = true)
+    public NewsDetailDto findNewsById(Long newsId) {
+        NewsArticle newsArticle = newsArticleRepository.findById(newsId).orElseThrow(() -> new NewsNotFoundException("존재하지 않는 뉴스 입니다." + newsId));
+        return NewsDetailDto.from(newsArticle, newsArticle.getContentBlocks());
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/domain/service/NewsContentProcessingService.java
+++ b/main-server/src/main/java/com/freedom/news/domain/service/NewsContentProcessingService.java
@@ -1,0 +1,178 @@
+package com.freedom.news.domain.service;
+
+import com.freedom.news.domain.model.ProcessedBlock;
+import com.freedom.news.domain.model.ProcessedNews;
+import lombok.RequiredArgsConstructor;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NewsContentProcessingService {
+
+    public ProcessedNews processHtmlContent(String htmlContent) {
+        try {
+            List<ProcessedBlock> blocks = isHtmlContent(htmlContent)
+                    ? parseHtmlContent(htmlContent)
+                    : parseTextContent(htmlContent);
+
+            String entirePlainText = extractPlainText(htmlContent);
+            return ProcessedNews.of(blocks, entirePlainText);
+
+        } catch (Exception e) {
+            return createFallbackContent(htmlContent);
+        }
+    }
+
+    private boolean isHtmlContent(String content) {
+        return content.contains("<") && content.contains(">");
+    }
+
+    private List<ProcessedBlock> parseHtmlContent(String htmlContent) {
+        Document document = Jsoup.parse(htmlContent);
+        List<ProcessedBlock> blocks = new ArrayList<>();
+
+        parseElement(document.body(), blocks);
+        return blocks;
+    }
+
+    private List<ProcessedBlock> parseTextContent(String textContent) {
+        List<ProcessedBlock> blocks = new ArrayList<>();
+        String[] paragraphs = textContent.split("\n\n");
+
+        for (String paragraph : paragraphs) {
+            String trimmed = paragraph.trim();
+            if (!trimmed.isEmpty()) {
+                blocks.add(ProcessedBlock.text(trimmed, trimmed));
+                blocks.add(ProcessedBlock.paragraphBreak());
+            }
+        }
+
+        removeLastParagraphBreak(blocks);
+        return blocks;
+    }
+
+    private void parseElement(Element element, List<ProcessedBlock> blocks) {
+        if (element == null) return;
+
+        for (Node node : element.childNodes()) {
+            if (node instanceof Element childElement) {
+                handleElement(childElement, blocks);
+            } else if (node instanceof TextNode textNode) {
+                handleTextNode(textNode, blocks);
+            }
+        }
+    }
+
+    private void handleElement(Element element, List<ProcessedBlock> blocks) {
+        String tagName = element.tagName().toLowerCase();
+
+        switch (tagName) {
+            case "p" -> addTextWithBreak(element, blocks);
+            case "h1", "h2", "h3", "h4", "h5", "h6" -> addHeading(element, tagName, blocks);
+            case "img" -> addImage(element, blocks);
+            case "figure" -> handleFigure(element, blocks);
+            case "br" -> blocks.add(ProcessedBlock.paragraphBreak());
+            case "div", "span" -> parseElement(element, blocks);
+            default -> addTextIfNotEmpty(element, blocks);
+        }
+    }
+
+    private void handleTextNode(TextNode textNode, List<ProcessedBlock> blocks) {
+        String original = textNode.text();
+        String plain = original.trim();
+        if (!plain.isEmpty()) {
+            blocks.add(ProcessedBlock.text(original, plain));
+        }
+    }
+
+    private void addTextWithBreak(Element element, List<ProcessedBlock> blocks) {
+        String originalHtml = element.outerHtml();
+        String plainText = element.text();
+        
+        if (!plainText.trim().isEmpty()) {
+            blocks.add(ProcessedBlock.text(originalHtml, plainText));
+            blocks.add(ProcessedBlock.paragraphBreak());
+        }
+    }
+
+    private void addHeading(Element element, String tagName, List<ProcessedBlock> blocks) {
+        String originalHtml = element.outerHtml();
+        String plainText = element.text();
+        
+        if (!plainText.trim().isEmpty()) {
+            int level = Integer.parseInt(tagName.substring(1));
+            blocks.add(ProcessedBlock.heading(originalHtml, plainText, level));
+        }
+    }
+
+    private void addImage(Element imgElement, List<ProcessedBlock> blocks) {
+        String src = imgElement.attr("src");
+        if (!src.isEmpty()) {
+            String alt = imgElement.attr("alt");
+            blocks.add(ProcessedBlock.image(src, alt));
+        }
+    }
+
+    private void handleFigure(Element figureElement, List<ProcessedBlock> blocks) {
+        // figure 내부의 img 태그 먼저 확인
+        Element imgElement = figureElement.selectFirst("img");
+        if (imgElement != null) {
+            // 이미지가 있을 때만 이미지와 캡션 모두 처리
+            addImage(imgElement, blocks);
+            
+            // figcaption 내용을 텍스트 블록으로 처리
+            Element figcaptionElement = figureElement.selectFirst("figcaption");
+            if (figcaptionElement != null) {
+                String originalHtml = figcaptionElement.outerHtml();
+                String plainText = figcaptionElement.text();
+                
+                if (!plainText.trim().isEmpty()) {
+                    blocks.add(ProcessedBlock.text(originalHtml, plainText));
+                }
+            }
+        }
+        // 이미지가 없으면 figure 전체를 무시
+    }
+
+    private void addTextIfNotEmpty(Element element, List<ProcessedBlock> blocks) {
+        String originalHtml = element.outerHtml();
+        String plainText = element.text();
+        
+        if (!plainText.trim().isEmpty()) {
+            blocks.add(ProcessedBlock.text(originalHtml, plainText));
+        }
+    }
+
+    private void removeLastParagraphBreak(List<ProcessedBlock> blocks) {
+        if (!blocks.isEmpty() && "paragraph_break".equals(blocks.get(blocks.size() - 1).getType())) {
+            blocks.removeLast();
+        }
+    }
+
+    private String extractPlainText(String htmlContent) {
+        if (!isHtmlContent(htmlContent)) {
+            return htmlContent.trim();
+        }
+
+        try {
+            Document document = Jsoup.parse(htmlContent);
+            return document.text();
+        } catch (Exception e) {
+            return htmlContent.replaceAll("<[^>]+>", "").trim();
+        }
+    }
+
+    private ProcessedNews createFallbackContent(String originalContent) {
+        String plainText = extractPlainText(originalContent);
+        List<ProcessedBlock> blocks = List.of(ProcessedBlock.text(originalContent, plainText));
+        return ProcessedNews.of(blocks, plainText);
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/domain/service/NewsExistingCheckService.java
+++ b/main-server/src/main/java/com/freedom/news/domain/service/NewsExistingCheckService.java
@@ -1,0 +1,68 @@
+package com.freedom.news.domain.service;
+
+import com.freedom.common.util.HashUtil;
+import com.freedom.news.application.dto.ExistingNewsDto;
+import com.freedom.news.domain.result.NewsClassificationResult;
+import com.freedom.news.infra.client.response.NewsItem;
+import com.freedom.news.infra.repository.NewsArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class NewsExistingCheckService {
+
+    private final NewsArticleRepository newsArticleRepository;
+
+    public NewsClassificationResult classifyNews(List<NewsItem> newsList) {
+        List<String> newsItemIds = newsList.stream()
+                .filter(news -> news.getGroupingCode().equals("policy"))
+                .map(NewsItem::getNewsItemId)
+                .toList();
+
+        Map<String, ExistingNewsDto> existingTodayNewsMap = getExistingTodayNewsMap(newsItemIds);
+
+        List<NewsItem> newNews = newsList.stream()
+                .filter(newsItem -> !existingTodayNewsMap.containsKey(newsItem.getNewsItemId()) && newsItem.getGroupingCode().equals("policy"))
+                .toList();
+
+        List<NewsItem> updatedNews = newsList.stream()
+                .filter(newsItem -> {
+                    ExistingNewsDto existing = existingTodayNewsMap.get(newsItem.getNewsItemId());
+                    if (existing == null || !newsItem.getGroupingCode().equals("policy")) return false;
+
+                    boolean modified = newsItem.getModifyId() != null
+                            && newsItem.getModifyId() > existing.getModifyId();
+
+                    String newHash = HashUtil.sha256(newsItem.getDataContents());
+                    boolean contentChanged = !newHash.equals(existing.getContentHash());
+
+                    return modified || contentChanged;
+                })
+                .toList();
+
+        return NewsClassificationResult.of(newNews, updatedNews);
+    }
+
+    private Map<String, ExistingNewsDto> getExistingTodayNewsMap(List<String> newsItemIds) {
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime startOfNextDay = startOfDay.plusDays(1);
+
+        List<ExistingNewsDto> existingTodayNews =
+                newsArticleRepository.findTodayNewsItemIdAndModifyIdAndHashByNewsItemIdIn(
+                        newsItemIds, startOfDay, startOfNextDay);
+
+        return existingTodayNews.stream()
+                .collect(Collectors.toMap(
+                        ExistingNewsDto::getNewsItemId,
+                        dto -> dto,
+                        (existing, replacement) -> existing
+                ));
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/domain/service/NewsPersistenceService.java
+++ b/main-server/src/main/java/com/freedom/news/domain/service/NewsPersistenceService.java
@@ -1,0 +1,33 @@
+package com.freedom.news.domain.service;
+
+
+import com.freedom.news.application.dto.NewsArticleDto;
+import com.freedom.news.domain.entity.NewsArticle;
+import com.freedom.news.infra.repository.NewsArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NewsPersistenceService {
+    private final NewsArticleRepository newsArticleRepository;
+
+    public void saveNewArticles(List<NewsArticleDto> newArticles) {
+        List<NewsArticle> entities = newArticles.stream()
+                .map(NewsArticleDto::toEntity)
+                .toList();
+        newsArticleRepository.saveAll(entities);
+    }
+
+    public void updateArticles(List<NewsArticleDto> updatedArticles) {
+        updatedArticles.forEach(dto -> {
+            NewsArticle entity = newsArticleRepository.findByNewsItemId(dto.getNewsItemId())
+                    .orElseThrow(() -> new IllegalStateException("기존 뉴스가 존재하지 않습니다. id=" + dto.getNewsItemId()));
+
+            entity.updateFromDto(dto);
+            newsArticleRepository.save(entity);
+        });
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/infra/client/OpenAiNewsSummaryClient.java
+++ b/main-server/src/main/java/com/freedom/news/infra/client/OpenAiNewsSummaryClient.java
@@ -1,0 +1,53 @@
+package com.freedom.news.infra.client;
+
+import com.freedom.news.infra.client.response.SummaryResponse;
+import com.openai.client.OpenAIClient;
+import com.openai.models.ChatModel;
+import com.openai.models.chat.completions.StructuredChatCompletionCreateParams;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OpenAiNewsSummaryClient {
+    private static final int LIMIT = 150;
+    private final OpenAIClient openAIClient;
+
+    public String summarize(String plainText) {
+        String prompt = """
+            당신은 한국어 뉴스 요약 전문가입니다.
+            아래 뉴스 본문을 읽고 조건을 반드시 지켜 1문장 요약을 작성하세요.
+
+            [조건]
+            - 본문에 없는 내용을 추가하거나 수정하지 마세요.
+            - 뉴스의 핵심 포인트를 한눈에 들어오게 작성하세요.
+            - 핵심 주체/행위/수치/날짜가 있으면 포함하세요.
+            - 기사 본문에 나온 사실만 사용하세요.
+            - 본문에 없는 정보·추측·해석·평가·의견·의역·보정 금지합니다.
+            - 출력은 오직 JSON: {"summary":"..."} (앞뒤 설명, 개행, 코드블록 없음)
+
+            [뉴스 본문]
+            %s
+            """.formatted(plainText);
+
+        StructuredChatCompletionCreateParams<SummaryResponse> params =
+                StructuredChatCompletionCreateParams.<SummaryResponse>builder()
+                        .model(ChatModel.GPT_4_1)
+                        .temperature(0.2)
+                        .maxCompletionTokens(220)
+                        .responseFormat(SummaryResponse.class)
+                        .addUserMessage(prompt)
+                        .build();
+
+        return openAIClient.chat()
+                .completions()
+                .create(params)
+                .choices()
+                .stream()
+                .flatMap(choice -> choice.message().content().stream())
+                .map(SummaryResponse::getSummary)
+                .findFirst()
+                .orElse("");
+    }
+
+}

--- a/main-server/src/main/java/com/freedom/news/infra/client/PolicyNewsClient.java
+++ b/main-server/src/main/java/com/freedom/news/infra/client/PolicyNewsClient.java
@@ -1,0 +1,121 @@
+package com.freedom.news.infra.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.freedom.common.logging.Loggable;
+import com.freedom.news.infra.client.response.NewsItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PolicyNewsClient {
+
+    @Value("${news.policy-briefing.service-key}")
+    private String serviceKey;
+
+    private final XmlMapper xmlMapper = new XmlMapper();
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    @Loggable("정책뉴스 API 조회")
+    public List<NewsItem> getNewsAPI() {
+        String today = LocalDate.now().format(DATE_FORMATTER);
+        return fetchNews(today, today);
+    }
+
+    private List<NewsItem> fetchNews(String startDate, String endDate) {
+        try {
+            String urlString = buildApiUrl(startDate, endDate);
+            String xmlResponse = executeHttpRequest(urlString);
+            return parseNewsItemsDirectly(xmlResponse);
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+    }
+
+    private String buildApiUrl(String startDate, String endDate) throws Exception {
+        return "http://apis.data.go.kr/1371000/policyNewsService/policyNewsList" + "?" + URLEncoder.encode("serviceKey", StandardCharsets.UTF_8) + "=" + serviceKey +
+                "&" + URLEncoder.encode("startDate", StandardCharsets.UTF_8) + "=" + URLEncoder.encode(startDate, StandardCharsets.UTF_8) +
+                "&" + URLEncoder.encode("endDate", StandardCharsets.UTF_8) + "=" + URLEncoder.encode(endDate, StandardCharsets.UTF_8);
+    }
+
+    private String executeHttpRequest(String urlString) throws Exception {
+        URL url = new URL(urlString);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+        try {
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("Content-type", "application/json");
+            conn.setConnectTimeout(30000);
+            conn.setReadTimeout(30000);
+
+            String result = getResult(conn);
+
+            if (result.contains("SERVICE_KEY_IS_NOT_REGISTERED_ERROR")) {
+                throw new RuntimeException("서비스키 미등록 오류");
+            } else if (result.contains("APPLICATION_ERROR")) {
+                throw new RuntimeException("API 애플리케이션 오류");
+            } else if (result.contains("INVALID_REQUEST_PARAMETER_ERROR")) {
+                throw new RuntimeException("잘못된 요청 파라미터");
+            }
+
+            return result;
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    private static String getResult(HttpURLConnection conn) throws IOException {
+        int responseCode = conn.getResponseCode();
+
+        BufferedReader reader = (responseCode >= 200 && responseCode <= 300)
+            ? new BufferedReader(new InputStreamReader(conn.getInputStream()))
+            : new BufferedReader(new InputStreamReader(conn.getErrorStream()));
+
+        StringBuilder response = new StringBuilder();
+        String line;
+        while ((line = reader.readLine()) != null) {
+            response.append(line);
+        }
+        reader.close();
+
+        return response.toString();
+    }
+
+    private List<NewsItem> parseNewsItemsDirectly(String xmlResponse) throws Exception {
+        try {
+            JsonNode rootNode = xmlMapper.readTree(xmlResponse);
+            JsonNode itemsNode = rootNode.at("/body/NewsItem");
+            List<NewsItem> items = new ArrayList<>();
+            if (itemsNode.isArray()) {
+                // 복수 아이템인 경우
+                for (JsonNode itemNode : itemsNode) {
+                    NewsItem item = xmlMapper.treeToValue(itemNode, NewsItem.class);
+                    items.add(item);
+                }
+            } else if (!itemsNode.isMissingNode()) {
+                // 단일 아이템인 경우
+                NewsItem item = xmlMapper.treeToValue(itemsNode, NewsItem.class);
+                items.add(item);
+            }
+            return items;
+        } catch (Exception e) {
+            throw new RuntimeException("NewsItem 파싱 실패", e);
+        }
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/infra/client/response/NewsItem.java
+++ b/main-server/src/main/java/com/freedom/news/infra/client/response/NewsItem.java
@@ -1,0 +1,74 @@
+package com.freedom.news.infra.client.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NewsItem {
+    
+    @JacksonXmlProperty(localName = "NewsItemId")
+    private String newsItemId;
+
+    @JacksonXmlProperty(localName = "ContentsStatus")
+    private String contentsStatus;
+
+    @JacksonXmlProperty(localName = "ModifyId")
+    private Integer modifyId;
+
+    @JacksonXmlProperty(localName = "ModifyDate")
+    private String modifyDate;
+
+    @JacksonXmlProperty(localName = "ApproveDate")
+    private String approveDate;
+
+    @JacksonXmlProperty(localName = "ApproverName")
+    private String approverName;
+
+    @JacksonXmlProperty(localName = "EmbargoDate")
+    private String embargoDate;
+
+    @JacksonXmlProperty(localName = "GroupingCode")
+    private String groupingCode;
+
+    @JacksonXmlProperty(localName = "Title")
+    private String title;
+
+    @JacksonXmlProperty(localName = "SubTitle1")
+    private String subTitle1;
+
+    @JacksonXmlProperty(localName = "SubTitle2")
+    private String subTitle2;
+
+    @JacksonXmlProperty(localName = "SubTitle3")
+    private String subTitle3;
+
+    @JacksonXmlProperty(localName = "ContentsType")
+    private String contentsType;
+
+    @JacksonXmlProperty(localName = "DataContents")
+    private String dataContents;
+
+    @JacksonXmlProperty(localName = "MinisterCode")
+    private String ministerCode;
+
+    @JacksonXmlProperty(localName = "ThumbnailUrl")
+    private String thumbnailUrl;
+
+    @JacksonXmlProperty(localName = "OriginalimgUrl")
+    private String originalImgUrl;
+
+    @JacksonXmlProperty(localName = "OriginalUrl")
+    private String originalUrl;
+}

--- a/main-server/src/main/java/com/freedom/news/infra/client/response/SummaryResponse.java
+++ b/main-server/src/main/java/com/freedom/news/infra/client/response/SummaryResponse.java
@@ -1,0 +1,12 @@
+package com.freedom.news.infra.client.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SummaryResponse {
+    @JsonProperty("summary")
+    private String summary;
+}

--- a/main-server/src/main/java/com/freedom/news/infra/repository/NewsArticleRepository.java
+++ b/main-server/src/main/java/com/freedom/news/infra/repository/NewsArticleRepository.java
@@ -1,0 +1,42 @@
+package com.freedom.news.infra.repository;
+
+import com.freedom.news.application.dto.ExistingNewsDto;
+import com.freedom.news.domain.entity.NewsArticle;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface NewsArticleRepository extends JpaRepository<NewsArticle, Long> {
+
+    @Query("""
+        SELECT new com.freedom.news.application.dto.ExistingNewsDto(
+            n.newsItemId, n.modifyId, n.contentHash
+        )
+        FROM NewsArticle n
+        WHERE n.newsItemId IN :newsItemIds
+          AND n.modifyDate BETWEEN :startOfDay AND :endOfDay
+    """)
+    List<ExistingNewsDto> findTodayNewsItemIdAndModifyIdAndHashByNewsItemIdIn(
+            @Param("newsItemIds") List<String> newsItemIds,
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay
+    );
+
+
+    Optional<NewsArticle> findByNewsItemId(String newsItemId);
+    
+    @Query("SELECT na FROM NewsArticle na WHERE na.approveDate >= :startDate AND na.approveDate < :endDate ORDER BY na.approveDate DESC")
+    Page<NewsArticle> findRecentNewsByApproveDateBetween(
+        @Param("startDate") LocalDateTime startDate,
+        @Param("endDate") LocalDateTime endDate,
+        Pageable pageable
+    );
+}

--- a/main-server/src/main/java/com/freedom/news/infra/repository/NewsContentBlockRepository.java
+++ b/main-server/src/main/java/com/freedom/news/infra/repository/NewsContentBlockRepository.java
@@ -1,0 +1,10 @@
+package com.freedom.news.infra.repository;
+
+import com.freedom.news.domain.entity.NewsContentBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NewsContentBlockRepository extends JpaRepository<NewsContentBlock, Long> {
+
+}

--- a/main-server/src/main/resources/application.yml
+++ b/main-server/src/main/resources/application.yml
@@ -15,6 +15,14 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
     open-in-view: false
 
+# Redis 설정
+redis:
+  main:
+    host: ${REDIS_MAIN_HOST:localhost}
+    port: ${REDIS_MAIN_PORT:6379}
+    password: ${REDIS_MAIN_PASSWORD:Test}
+    ssl: true
+
 # JWT 설정
 jwt:
   secret: ${JWT_SECRET:your-secret-key-must-be-at-least-256-bits-long-for-security}
@@ -22,6 +30,21 @@ jwt:
     expiration: 1800000    # 30분
   refresh-token:
     expiration: 1209600000 # 14일
+
+# 뉴스 API 설정
+news:
+  policy-briefing:
+    service-key: ${NEWS_SERVICE_KEY}
+
+  scheduler:
+    cron: "0 0 0,6,12,18 * * *"  # 매 6시간마다 실행 (0시, 6시, 12시, 18시)
+    zone: "Asia/Seoul"  # 한국 시간대
+
+openai:
+  api-key: ${OPENAI_API_KEY}
+
+discord:
+  webhook-url: ${DISCORD_WEBHOOK_URL}
 
 # 로깅 설정
 logging:

--- a/main-server/src/test/java/com/freedom/common/test/TestContainerConfig.java
+++ b/main-server/src/test/java/com/freedom/common/test/TestContainerConfig.java
@@ -4,6 +4,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -13,26 +14,32 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @ActiveProfiles("test")
 public abstract class TestContainerConfig {
 
-    @Container
-    protected static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>("mysql:8.4.5")
-            .withDatabaseName("test_financial_freedom")
-            .withUsername("test_user")
-            .withPassword("test_password")
-            .withCommand("--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci")
-            .withReuse(true);
+
+    protected static MySQLContainer<?> mysql;
+
+    static {
+        mysql = new MySQLContainer<>("mysql:8.4.5")
+                .withDatabaseName("test_financial_freedom")
+                .withUsername("test_user")
+                .withPassword("test_password")
+                .withCommand("--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci", "--default-time-zone=+09:00")
+                .withReuse(true);
+
+        mysql.start();
+    }
 
     @DynamicPropertySource
-    static void configureTestProperties(DynamicPropertyRegistry registry) {
+    static void configureProperties(DynamicPropertyRegistry registry) {
         // Database 설정
-        registry.add("spring.datasource.url", MYSQL_CONTAINER::getJdbcUrl);
-        registry.add("spring.datasource.username", MYSQL_CONTAINER::getUsername);
-        registry.add("spring.datasource.password", MYSQL_CONTAINER::getPassword);
-        
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+
         // JPA 설정 - 테스트용 최적화
         registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
         registry.add("spring.jpa.show-sql", () -> "false"); // 로그 간소화
         registry.add("spring.jpa.properties.hibernate.format_sql", () -> "false");
-        
+
         // 기타 테스트 최적화 설정
         registry.add("logging.level.org.springframework.web", () -> "WARN");
         registry.add("logging.level.org.testcontainers", () -> "WARN");

--- a/main-server/src/test/java/com/freedom/news/api/NewsControllerIntegrationTest.java
+++ b/main-server/src/test/java/com/freedom/news/api/NewsControllerIntegrationTest.java
@@ -1,0 +1,128 @@
+package com.freedom.news.api;
+
+import com.freedom.auth.domain.User;
+import com.freedom.auth.domain.UserRole;
+import com.freedom.auth.domain.UserStatus;
+import com.freedom.auth.infra.UserJpaRepository;
+import com.freedom.common.security.JwtProvider;
+import com.freedom.common.test.TestContainerConfig;
+import com.freedom.news.api.response.NewsDetailResponse;
+import com.freedom.news.infra.repository.NewsArticleRepository;
+import com.freedom.news.infra.repository.NewsContentBlockRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("NewsController API 통합 테스트")
+@Sql("/test-data.sql")
+class NewsControllerIntegrationTest extends TestContainerConfig {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private NewsArticleRepository newsArticleRepository;
+
+    @Autowired
+    private NewsContentBlockRepository newsContentBlockRepository;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    private Long userId;
+
+    private String getAuthorizationHeader() {
+        String accessToken = jwtProvider.createAccessToken(userId);
+        return "Bearer " + accessToken;
+    }
+
+    @BeforeEach
+    void setUp() {
+        User user = User.builder().email("test@exmple.com").password("test12345@").role(UserRole.USER).status(UserStatus.ACTIVE).build();
+        User saveUser = userJpaRepository.save(user);
+        userId = saveUser.getId();
+    }
+
+    @AfterEach
+    void tearDown() {
+        userJpaRepository.deleteAll();
+        newsContentBlockRepository.deleteAll();
+        newsArticleRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("뉴스 리스트 조회 성공 - 기본 페이징")
+    void getNewsList_Success_DefaultPaging() {
+        webTestClient.get()
+                .uri("/api/news")
+                .header("Authorization", getAuthorizationHeader())
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.content").isArray()
+                .jsonPath("$.content.length()").isEqualTo(2)
+                .jsonPath("$.content[0].title").isEqualTo("오늘 정책 뉴스 제목")
+                .jsonPath("$.content[1].title").isEqualTo("어제 정책 뉴스 제목")
+                .jsonPath("$.size").isEqualTo(10)
+                .jsonPath("$.totalElements").isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("뉴스 리스트 조회 성공 - 커스텀 페이징")
+    void getNewsList_Success_CustomPaging() {
+        webTestClient.get()
+                .uri("/api/news?page=0&size=1")
+                .header("Authorization", getAuthorizationHeader())
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.content").isArray()
+                .jsonPath("$.content[0].title").isEqualTo("오늘 정책 뉴스 제목")
+                .jsonPath("$.totalElements").isEqualTo(2)
+                .jsonPath("$.size").isEqualTo(1)
+                .jsonPath("$.number").isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("뉴스 상세 조회 성공")
+    void getNewsDetail_Success() {
+        webTestClient.get()
+                .uri("/api/news/1")
+                .header("Authorization", getAuthorizationHeader())
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(NewsDetailResponse.class)
+                .value(response -> {
+                    assertThat(response.getId()).isEqualTo(1L);
+                    assertThat(response.getNewsItemId()).isEqualTo("news001");
+                    assertThat(response.getTitle()).isEqualTo("어제 정책 뉴스 제목");
+                    assertThat(response.getAiSummary()).isEqualTo("AI 요약: 어제 중요한 정책 발표");
+                    assertThat(response.getContentBlocks()).hasSize(2);
+                    
+                    assertThat(response.getContentBlocks().get(0).getBlockType()).isEqualTo("TEXT");
+                    assertThat(response.getContentBlocks().get(0).getPlainContent()).isEqualTo("첫 번째 텍스트 블록");
+                    assertThat(response.getContentBlocks().get(1).getBlockType()).isEqualTo("IMAGE");
+                    assertThat(response.getContentBlocks().get(1).getUrl()).isEqualTo("https://example.com/test.jpg");
+                });
+    }
+
+    @Test
+    @DisplayName("뉴스 상세 조회 실패 - 존재하지 않는 뉴스")
+    void getNewsDetail_Fail_NotFound() {
+        webTestClient.get()
+                .uri("/api/news/999999")
+                .header("Authorization", getAuthorizationHeader())
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody()
+                .jsonPath("$.message").value(message -> 
+                    assertThat(message.toString()).contains("뉴스를 찾을 수 없습니다.")
+                );
+    }
+}

--- a/main-server/src/test/java/com/freedom/news/application/facade/NewsQueryAppServiceTest.java
+++ b/main-server/src/test/java/com/freedom/news/application/facade/NewsQueryAppServiceTest.java
@@ -1,0 +1,150 @@
+package com.freedom.news.application.facade;
+
+import com.freedom.common.exception.custom.NewsNotFoundException;
+import com.freedom.news.api.response.NewsDetailResponse;
+import com.freedom.news.api.response.NewsResponse;
+import com.freedom.news.application.dto.NewsContentBlockDto;
+import com.freedom.news.application.dto.NewsDetailDto;
+import com.freedom.news.application.dto.NewsDto;
+import com.freedom.news.domain.service.FindNewsService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NewsQueryAppService 단위 테스트")
+class NewsQueryAppServiceTest {
+
+    @Mock
+    private FindNewsService findNewsService;
+
+    @InjectMocks
+    private NewsQueryAppService newsQueryAppService;
+
+    @Test
+    @DisplayName("뉴스 리스트 조회 성공")
+    void getRecentNewsList_Success() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        
+        NewsDto mockNews = createMockNewsDto();
+        Page<NewsDto> mockPage = new PageImpl<>(List.of(mockNews), pageable, 1);
+        
+        given(findNewsService.findRecentNews(any(Pageable.class)))
+            .willReturn(mockPage);
+
+        // when
+        Page<NewsResponse> result = newsQueryAppService.getRecentNewsList(0, 10);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo("테스트 제목");
+        assertThat(result.getContent().get(0).getNewsItemId()).isEqualTo("news001");
+        assertThat(result.getContent().get(0).getAiSummary()).isEqualTo("AI 요약");
+        assertThat(result.getTotalElements()).isEqualTo(1);
+
+        verify(findNewsService).findRecentNews(any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("뉴스 상세 조회 성공")
+    void getNewsDetail_Success() {
+        // given
+        Long newsId = 1L;
+        NewsDetailDto mockNews = createMockNewsDetailDto();
+        
+        given(findNewsService.findNewsById(newsId))
+            .willReturn(mockNews);
+
+        // when
+        NewsDetailResponse result = newsQueryAppService.getNewsDetail(newsId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getTitle()).isEqualTo("테스트 제목");
+        assertThat(result.getContentBlocks()).hasSize(2);
+        assertThat(result.getContentBlocks().get(0).getBlockType()).isEqualTo("TEXT");
+        assertThat(result.getContentBlocks().get(1).getBlockType()).isEqualTo("IMAGE");
+
+        verify(findNewsService).findNewsById(newsId);
+    }
+
+    @Test
+    @DisplayName("뉴스 상세 조회 실패 - 존재하지 않는 뉴스")
+    void getNewsDetail_Fail_NotFound() {
+        // given
+        Long newsId = 999L;
+        
+        given(findNewsService.findNewsById(newsId))
+            .willThrow(new NewsNotFoundException("존재하지 않는 뉴스 입니다." + newsId));
+
+        // when & then
+        assertThatThrownBy(() -> newsQueryAppService.getNewsDetail(newsId))
+            .isInstanceOf(NewsNotFoundException.class)
+            .hasMessageContaining("존재하지 않는 뉴스 입니다.");
+
+        verify(findNewsService).findNewsById(newsId);
+    }
+
+    private NewsDto createMockNewsDto() {
+        return NewsDto.builder()
+                .id(1L)
+                .newsItemId("news001")
+                .title("테스트 제목")
+                .subTitle1("부제목1")
+                .subTitle2("부제목2")
+                .subTitle3("부제목3")
+                .approveDate(LocalDateTime.now())
+                .modifyDate(LocalDateTime.now())
+                .thumbnailUrl("https://example.com/thumb.jpg")
+                .aiSummary("AI 요약")
+                .plainTextContent("본문 내용")
+                .build();
+    }
+
+    private NewsDetailDto createMockNewsDetailDto() {
+        List<NewsContentBlockDto> contentBlocks = List.of(
+            NewsContentBlockDto.builder()
+                .blockType("TEXT")
+                .originalContent("<p>텍스트 블록</p>")
+                .plainContent("텍스트 블록")
+                .blockOrder(1)
+                .build(),
+            NewsContentBlockDto.builder()
+                .blockType("IMAGE")
+                .originalContent("<img src='test.jpg'>")
+                .url("https://example.com/test.jpg")
+                .altText("테스트 이미지")
+                .blockOrder(2)
+                .build()
+        );
+
+        return NewsDetailDto.builder()
+                .id(1L)
+                .newsItemId("news001")
+                .title("테스트 제목")
+                .approveDate(LocalDateTime.now())
+                .modifyDate(LocalDateTime.now())
+                .thumbnailUrl("https://example.com/thumb.jpg")
+                .aiSummary("AI 요약")
+                .plainTextContent("본문 내용")
+                .contentBlocks(contentBlocks)
+                .build();
+    }
+}

--- a/main-server/src/test/java/com/freedom/news/domain/service/FindNewsServiceTest.java
+++ b/main-server/src/test/java/com/freedom/news/domain/service/FindNewsServiceTest.java
@@ -1,0 +1,120 @@
+package com.freedom.news.domain.service;
+
+import com.freedom.common.exception.custom.NewsNotFoundException;
+import com.freedom.news.application.dto.NewsDetailDto;
+import com.freedom.news.application.dto.NewsDto;
+import com.freedom.news.domain.entity.NewsArticle;
+import com.freedom.news.infra.repository.NewsArticleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FindNewsService 단위 테스트")
+class FindNewsServiceTest {
+
+    @Mock
+    private NewsArticleRepository newsArticleRepository;
+
+    @InjectMocks
+    private FindNewsService findNewsService;
+
+    @Test
+    @DisplayName("평일 뉴스 조회 - 어제~오늘 범위")
+    void findRecentNews_Weekday_Success() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        NewsArticle mockNews = createMockNewsArticle("news001", "테스트 뉴스");
+        Page<NewsArticle> mockPage = new PageImpl<>(List.of(mockNews), pageable, 1);
+
+        given(newsArticleRepository.findRecentNewsByApproveDateBetween(
+            any(LocalDateTime.class), 
+            any(LocalDateTime.class), 
+            eq(pageable)
+        )).willReturn(mockPage);
+
+        // when
+        Page<NewsDto> result = findNewsService.findRecentNews(pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo("테스트 뉴스");
+        assertThat(result.getTotalElements()).isEqualTo(1);
+
+        verify(newsArticleRepository).findRecentNewsByApproveDateBetween(
+            any(LocalDateTime.class), 
+            any(LocalDateTime.class), 
+            eq(pageable)
+        );
+    }
+
+    @Test
+    @DisplayName("뉴스 상세 조회 성공")
+    void findNewsById_Success() {
+        // given
+        Long newsId = 1L;
+        NewsArticle mockNews = createMockNewsArticle("news001", "상세 뉴스");
+        
+        given(newsArticleRepository.findById(newsId))
+            .willReturn(Optional.of(mockNews));
+
+        // when
+        NewsDetailDto result = findNewsService.findNewsById(newsId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getTitle()).isEqualTo("상세 뉴스");
+        
+        verify(newsArticleRepository).findById(newsId);
+    }
+
+    @Test
+    @DisplayName("뉴스 상세 조회 실패 - 존재하지 않는 ID")
+    void findNewsById_NotFound() {
+        // given
+        Long newsId = 999L;
+        
+        given(newsArticleRepository.findById(newsId))
+            .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> findNewsService.findNewsById(newsId))
+            .isInstanceOf(NewsNotFoundException.class)
+            .hasMessageContaining("존재하지 않는 뉴스 입니다.");
+        
+        verify(newsArticleRepository).findById(newsId);
+    }
+
+    private NewsArticle createMockNewsArticle(String newsItemId, String title) {
+        return NewsArticle.builder()
+                .newsItemId(newsItemId)
+                .title(title)
+                .contentsStatus("U")
+                .modifyId(1)
+                .approveDate(LocalDateTime.now().minusHours(1))
+                .groupingCode("policy")
+                .contentsType("H")
+                .dataContents("<p>테스트 내용</p>")
+                .plainTextContent("테스트 내용")
+                .contentHash("testhash")
+                .build();
+    }
+}

--- a/main-server/src/test/java/com/freedom/news/domain/service/NewsExistingCheckServiceTest.java
+++ b/main-server/src/test/java/com/freedom/news/domain/service/NewsExistingCheckServiceTest.java
@@ -1,0 +1,185 @@
+package com.freedom.news.domain.service;
+
+import com.freedom.news.application.dto.ExistingNewsDto;
+import com.freedom.news.domain.result.NewsClassificationResult;
+import com.freedom.news.infra.client.response.NewsItem;
+import com.freedom.news.infra.repository.NewsArticleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NewsExistingCheckService 단위 테스트")
+class NewsExistingCheckServiceTest {
+
+    @Mock
+    private NewsArticleRepository newsArticleRepository;
+
+    @InjectMocks
+    private NewsExistingCheckService newsExistingCheckService;
+
+    @Test
+    @DisplayName("신규 뉴스 분류 성공")
+    void classifyNews_Success_NewNews() {
+        // given
+        List<NewsItem> newsList = List.of(
+            createMockNewsItem("news001", 1, "<p>새로운 내용</p>"),
+            createMockNewsItem("news002", 1, "<p>또 다른 새로운 내용</p>")
+        );
+
+        // DB에 기존 뉴스 없음
+        given(newsArticleRepository.findTodayNewsItemIdAndModifyIdAndHashByNewsItemIdIn(
+            anyList(), any(LocalDateTime.class), any(LocalDateTime.class)
+        )).willReturn(List.of());
+
+        // when
+        NewsClassificationResult result = newsExistingCheckService.classifyNews(newsList);
+
+        // then
+        assertThat(result.getNewNews()).hasSize(2);
+        assertThat(result.getUpdatedNews()).isEmpty();
+        assertThat(result.hasNewsToProcess()).isTrue();
+
+        verify(newsArticleRepository).findTodayNewsItemIdAndModifyIdAndHashByNewsItemIdIn(
+            anyList(), any(LocalDateTime.class), any(LocalDateTime.class)
+        );
+    }
+
+    @Test
+    @DisplayName("업데이트된 뉴스 분류 성공 - modifyId 증가")
+    void classifyNews_Success_UpdatedNewsByModifyId() {
+        // given
+        List<NewsItem> newsList = List.of(
+            createMockNewsItem("news001", 2, "<p>기존 내용</p>") // modifyId 증가
+        );
+
+        // DB에 기존 뉴스 있음 (modifyId = 1)
+        List<ExistingNewsDto> existingNews = List.of(
+            new ExistingNewsDto("news001", 1, "existing_hash")
+        );
+        given(newsArticleRepository.findTodayNewsItemIdAndModifyIdAndHashByNewsItemIdIn(
+            anyList(), any(LocalDateTime.class), any(LocalDateTime.class)
+        )).willReturn(existingNews);
+
+        // when
+        NewsClassificationResult result = newsExistingCheckService.classifyNews(newsList);
+
+        // then
+        assertThat(result.getNewNews()).isEmpty();
+        assertThat(result.getUpdatedNews()).hasSize(1);
+        assertThat(result.getUpdatedNews().get(0).getNewsItemId()).isEqualTo("news001");
+        assertThat(result.hasNewsToProcess()).isTrue();
+    }
+
+    @Test
+    @DisplayName("업데이트된 뉴스 분류 성공 - 컨텐츠 변경")
+    void classifyNews_Success_UpdatedNewsByContentChange() {
+        // given
+        List<NewsItem> newsList = List.of(
+            createMockNewsItem("news001", 1, "<p>변경된 내용</p>") // 컨텐츠 변경
+        );
+
+        // DB에 기존 뉴스 있음 (같은 modifyId, 다른 해시)
+        List<ExistingNewsDto> existingNews = List.of(
+            new ExistingNewsDto("news001", 1, "different_hash")
+        );
+        given(newsArticleRepository.findTodayNewsItemIdAndModifyIdAndHashByNewsItemIdIn(
+            anyList(), any(LocalDateTime.class), any(LocalDateTime.class)
+        )).willReturn(existingNews);
+
+        // when
+        NewsClassificationResult result = newsExistingCheckService.classifyNews(newsList);
+
+        // then
+        assertThat(result.getNewNews()).isEmpty();
+        assertThat(result.getUpdatedNews()).hasSize(1);
+        assertThat(result.getUpdatedNews().get(0).getNewsItemId()).isEqualTo("news001");
+    }
+
+    @Test
+    @DisplayName("변경되지 않은 뉴스 필터링")
+    void classifyNews_Success_NoChanges() {
+        // given
+        String content = "<p>동일한 내용</p>";
+        List<NewsItem> newsList = List.of(
+            createMockNewsItem("news001", 1, content)
+        );
+
+        // DB에 동일한 뉴스 있음
+        String expectedHash = com.freedom.common.util.HashUtil.sha256(content);
+        List<ExistingNewsDto> existingNews = List.of(
+            new ExistingNewsDto("news001", 1, expectedHash)
+        );
+        given(newsArticleRepository.findTodayNewsItemIdAndModifyIdAndHashByNewsItemIdIn(
+            anyList(), any(LocalDateTime.class), any(LocalDateTime.class)
+        )).willReturn(existingNews);
+
+        // when
+        NewsClassificationResult result = newsExistingCheckService.classifyNews(newsList);
+
+        // then
+        assertThat(result.getNewNews()).isEmpty();
+        assertThat(result.getUpdatedNews()).isEmpty();
+        assertThat(result.hasNewsToProcess()).isFalse();
+    }
+
+    @Test
+    @DisplayName("혼합 케이스 - 신규, 업데이트, 변경없음")
+    void classifyNews_Success_MixedCases() {
+        // given
+        List<NewsItem> newsList = List.of(
+            createMockNewsItem("news001", 1, "<p>새로운 뉴스</p>"), // 신규
+            createMockNewsItem("news002", 2, "<p>업데이트된 뉴스</p>"), // 업데이트 (modifyId)
+            createMockNewsItem("news003", 1, "<p>변경된 내용</p>"), // 업데이트 (내용)
+            createMockNewsItem("news004", 1, "<p>동일한 내용</p>") // 변경없음
+        );
+
+        // DB에 일부 기존 뉴스 있음
+        String unchangedHash = com.freedom.common.util.HashUtil.sha256("<p>동일한 내용</p>");
+        List<ExistingNewsDto> existingNews = List.of(
+            new ExistingNewsDto("news002", 1, "old_hash"), // modifyId 증가됨
+            new ExistingNewsDto("news003", 1, "different_hash"), // 내용 변경됨
+            new ExistingNewsDto("news004", 1, unchangedHash) // 변경없음
+        );
+        given(newsArticleRepository.findTodayNewsItemIdAndModifyIdAndHashByNewsItemIdIn(
+            anyList(), any(LocalDateTime.class), any(LocalDateTime.class)
+        )).willReturn(existingNews);
+
+        // when
+        NewsClassificationResult result = newsExistingCheckService.classifyNews(newsList);
+
+        // then
+        assertThat(result.getNewNews()).hasSize(1);
+        assertThat(result.getNewNews().get(0).getNewsItemId()).isEqualTo("news001");
+        
+        assertThat(result.getUpdatedNews()).hasSize(2);
+        assertThat(result.getUpdatedNews())
+            .extracting(NewsItem::getNewsItemId)
+            .containsExactlyInAnyOrder("news002", "news003");
+
+        assertThat(result.hasNewsToProcess()).isTrue();
+    }
+
+    private NewsItem createMockNewsItem(String newsItemId, Integer modifyId, String content) {
+        return NewsItem.builder()
+                .newsItemId(newsItemId)
+                .modifyId(modifyId)
+                .dataContents(content)
+                .title("테스트 제목")
+                .contentsStatus("U")
+                .groupingCode("policy")
+                .build();
+    }
+}

--- a/main-server/src/test/java/com/freedom/news/domain/service/NewsPersistenceServiceTest.java
+++ b/main-server/src/test/java/com/freedom/news/domain/service/NewsPersistenceServiceTest.java
@@ -1,0 +1,121 @@
+package com.freedom.news.domain.service;
+
+import com.freedom.news.application.dto.NewsArticleDto;
+import com.freedom.news.domain.entity.NewsArticle;
+import com.freedom.news.infra.repository.NewsArticleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NewsPersistenceService 단위 테스트")
+class NewsPersistenceServiceTest {
+
+    @Mock
+    private NewsArticleRepository newsArticleRepository;
+
+    @InjectMocks
+    private NewsPersistenceService newsPersistenceService;
+
+    @Test
+    @DisplayName("신규 뉴스 저장 성공")
+    void saveNewArticles_Success() {
+        // given
+        List<NewsArticleDto> newArticles = List.of(
+            createMockNewsArticleDto("news001", "첫 번째 뉴스"),
+            createMockNewsArticleDto("news002", "두 번째 뉴스")
+        );
+
+        given(newsArticleRepository.saveAll(anyList())).willReturn(List.of());
+
+        // when
+        newsPersistenceService.saveNewArticles(newArticles);
+
+        // then
+        verify(newsArticleRepository).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("뉴스 업데이트 성공")
+    void updateArticles_Success() {
+        // given
+        NewsArticleDto updateDto = createMockNewsArticleDto("news001", "업데이트된 뉴스");
+        List<NewsArticleDto> updateArticles = List.of(updateDto);
+
+        NewsArticle existingArticle = NewsArticle.builder()
+                .newsItemId("news001")
+                .title("기존 제목")
+                .contentsStatus("U")
+                .modifyId(1)
+                .groupingCode("policy")
+                .contentsType("H")
+                .dataContents("<p>기존 내용</p>")
+                .plainTextContent("기존 내용")
+                .contentHash("old_hash")
+                .build();
+
+        given(newsArticleRepository.findByNewsItemId("news001"))
+            .willReturn(Optional.of(existingArticle));
+        given(newsArticleRepository.save(any(NewsArticle.class)))
+            .willReturn(existingArticle);
+
+        // when
+        newsPersistenceService.updateArticles(updateArticles);
+
+        // then
+        verify(newsArticleRepository).findByNewsItemId("news001");
+        verify(newsArticleRepository).save(any(NewsArticle.class));
+    }
+
+    @Test
+    @DisplayName("뉴스 업데이트 실패 - 기존 뉴스 없음")
+    void updateArticles_Fail_NewsNotFound() {
+        // given
+        NewsArticleDto updateDto = createMockNewsArticleDto("news999", "존재하지 않는 뉴스");
+        List<NewsArticleDto> updateArticles = List.of(updateDto);
+
+        given(newsArticleRepository.findByNewsItemId("news999"))
+            .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> newsPersistenceService.updateArticles(updateArticles))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("기존 뉴스가 존재하지 않습니다");
+
+        verify(newsArticleRepository).findByNewsItemId("news999");
+    }
+
+    private NewsArticleDto createMockNewsArticleDto(String newsItemId, String title) {
+        return NewsArticleDto.builder()
+                .newsItemId(newsItemId)
+                .title(title)
+                .contentsStatus("U")
+                .modifyId(1)
+                .modifyDate(LocalDateTime.now())
+                .approveDate(LocalDateTime.now().minusHours(1))
+                .approverName("테스트승인자")
+                .groupingCode("policy")
+                .subTitle1("부제목")
+                .contentsType("H")
+                .dataContents("<p>" + title + " 내용</p>")
+                .plainTextContent(title + " 내용")
+                .ministerCode("TEST")
+                .thumbnailUrl("https://example.com/thumb.jpg")
+                .originalUrl("https://example.com/news/" + newsItemId)
+                .aiSummary("AI 생성 요약")
+                .build();
+    }
+}

--- a/main-server/src/test/resources/test-data.sql
+++ b/main-server/src/test/resources/test-data.sql
@@ -1,0 +1,39 @@
+-- 테스트용 사용자 데이터
+INSERT INTO users (
+    id, email, password, role, status, character_created, created_at, updated_at
+) VALUES
+(1, 'test@example.com', '$2a$10$N.zmdr9k7uOCQb376NoUnOmTOPSwz5WJQGYM/cR5lRhXRHGkDTcmK', 'USER', 'ACTIVE', false, NOW(), NOW());
+
+-- 테스트용 뉴스 데이터
+INSERT INTO news_article (
+    id, news_item_id, contents_status, modify_id, modify_date, approve_date, approver_name,
+    grouping_code, title, sub_title1, contents_type, data_contents, plain_text_content,
+    content_hash, thumbnail_url, ai_summary, created_at, updated_at
+) VALUES
+-- 어제 뉴스 (ID: 1)
+(1, 'news001', 'U', 1, 
+ DATE_SUB(NOW(), INTERVAL 1 DAY), DATE_SUB(NOW(), INTERVAL 1 DAY), '테스트승인자1',
+ 'policy', '어제 정책 뉴스 제목', '어제 부제목1',
+ 'H', '<p>어제 뉴스 내용입니다.</p>', '어제 뉴스 내용입니다.',
+ 'hash001', 'https://example.com/thumb1.jpg', 'AI 요약: 어제 중요한 정책 발표', NOW(), NOW()),
+
+-- 오늘 뉴스 (ID: 2) 
+(2, 'news002', 'U', 1,
+ NOW(), NOW(), '테스트승인자2',
+ 'policy', '오늘 정책 뉴스 제목', '오늘 부제목1',
+ 'H', '<p>오늘 뉴스 내용입니다.</p>', '오늘 뉴스 내용입니다.',
+ 'hash002', 'https://example.com/thumb2.jpg', 'AI 요약: 오늘 새로운 정책 방향', NOW(), NOW()),
+
+-- 일주일 전 뉴스 (조회되면 안됨)
+(3, 'news003', 'U', 1,
+ DATE_SUB(NOW(), INTERVAL 7 DAY), DATE_SUB(NOW(), INTERVAL 7 DAY), '테스트승인자3',
+ 'policy', '일주일 전 뉴스', '오래된 부제목',
+ 'H', '<p>일주일 전 뉴스</p>', '일주일 전 뉴스',
+ 'hash003', 'https://example.com/thumb3.jpg', 'AI 요약: 오래된 뉴스', NOW(), NOW());
+
+-- 뉴스 컨텐츠 블록 (첫 번째 뉴스용)
+INSERT INTO news_content_block (
+    id, news_article_id, block_type, original_content, plain_content, url, alt_text, block_order, created_at, updated_at
+) VALUES
+(1, 1, 'TEXT', '<p>첫 번째 텍스트 블록</p>', '첫 번째 텍스트 블록', NULL, NULL, 1, NOW(), NOW()),
+(2, 1, 'IMAGE', '<img src="test.jpg" alt="테스트 이미지">', '', 'https://example.com/test.jpg', '테스트 이미지', 2, NOW(), NOW());


### PR DESCRIPTION
# 뉴스 기능 구현 PR

##  주요 기능

### 1. 뉴스 목록 조회 (뉴스 모아보기/골라보기)
- 페이징 기반의 최신 뉴스 목록 제공
- 뉴스 제목, 썸네일, AI 요약 정보 포함
- 최신순 정렬

### 2. 뉴스 상세 조회
- 뉴스 전체 내용 및 구조화된 콘텐츠 블록 제공
- 이미지, 텍스트 등 다양한 콘텐츠 타입 지원
- AI 요약 및 원문 내용 제공

### 3. 뉴스 스크랩 기능 (예정)
- 관심 뉴스 스크랩 및 관리 (향후 구현 예정)

### 4. 자동 뉴스 수집 및 처리
- 정책브리핑 API 연동을 통한 정책 뉴스 자동 수집
- OpenAI API를 통한 뉴스 내용 자동 요약
- 3시간마다 자동 업데이트 (평일 기준)
- 중복 뉴스 방지 시스템

## 아키텍처

### 계층별 구조
```
📁 news/
├── 📁 api/                    # API 계층
│   ├── NewsController.java    # REST API 엔드포인트
│   └── 📁 response/           # API 응답 DTO
├── 📁 application/            # 애플리케이션 계층
│   ├── 📁 facade/             # 퍼사드 패턴
│   ├── 📁 dto/                # 데이터 전송 객체
│   └── 📁 schedule/           # 스케줄러
├── 📁 domain/                 # 도메인 계층
│   ├── 📁 entity/             # JPA 엔티티
│   ├── 📁 service/            # 도메인 서비스
│   └── 📁 model/              # 도메인 모델
└── 📁 infra/                  # 인프라 계층
    ├── 📁 repository/         # 데이터 접근
    └── 📁 client/             # 외부 API 클라이언트
```

### 데이터베이스 설계
- **news_article**: 뉴스 기사 메인 테이블
- **news_content_block**: 뉴스 콘텐츠 블록 테이블 (1:N 관계)


## 주요 컴포넌트

### API 계층
- `NewsController`: 뉴스 관련 REST API 제공

### 애플리케이션 계층
- `NewsQueryAppService`: 뉴스 조회 관련 비즈니스 로직
- `NewsFacade`: 뉴스 수집 및 처리 오케스트레이션
- `NewsScheduler`: 정기적 뉴스 수집 스케줄링

### 도메인 계층
- `NewsArticle`: 뉴스 기사 엔티티
- `NewsContentBlock`: 뉴스 콘텐츠 블록 엔티티
- `FindNewsService`: 뉴스 조회 도메인 서비스
- `NewsContentProcessingService`: 뉴스 콘텐츠 처리 서비스

### 인프라 계층
- `PolicyNewsClient`: 정책브리핑 API 클라이언트
- `OpenAiNewsSummaryClient`: OpenAI API 클라이언트

## 🔄 처리 플로우

### 뉴스 수집 플로우
1. `NewsScheduler`가 3시간마다 실행 - 개발 단계에서는 6시간 설정(ai 요금 문제)
2. `PolicyNewsClient`를 통해 정책브리핑 API 호출
3. `NewsExistingCheckService`로 중복 뉴스 확인
4. `NewsContentProcessingService`로 콘텐츠 구조화
5. `OpenAiNewsSummaryClient`로 AI 요약 생성
6. `NewsPersistenceService`로 데이터베이스 저장

### 뉴스 조회 플로우
1. 클라이언트에서 REST API 호출
2. `NewsQueryAppService`에서 비즈니스 로직 처리
3. `FindNewsService`에서 데이터 조회
4. Response DTO로 변환하여 반환

## 테스트
- 단위 테스트: 각 계층별 컴포넌트 테스트
- 통합 테스트: API 엔드포인트 테스트

## 📋 체크리스트
- [x] 뉴스 목록 API 구현
- [x] 뉴스 상세 API 구현
- [x] 자동 뉴스 수집 스케줄러 구현
- [x] AI 요약 기능 구현
- [x] 예외 처리 구현
- [x] 테스트 코드 작성
- [ ] 뉴스 스크랩 API 구현 (향후)
