### PR TITLE
적금 상품 조회 API - 스냅샷 기반 Read 전용

### DIFF
--- a/main-server/src/main/java/com/freedom/MainServerApplication.java
+++ b/main-server/src/main/java/com/freedom/MainServerApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class MainServerApplication {
 
 	public static void main(String[] args) {

--- a/main-server/src/main/java/com/freedom/common/exception/ErrorCode.java
+++ b/main-server/src/main/java/com/freedom/common/exception/ErrorCode.java
@@ -28,7 +28,10 @@ public enum ErrorCode {
     DUPLICATE_EMAIL("USER002", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),
     INVALID_PASSWORD("USER003", "비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
     USER_WITHDRAWN("USER004", "탈퇴한 사용자입니다.", HttpStatus.FORBIDDEN),
-    USER_SUSPENDED("USER005", "정지된 사용자입니다.", HttpStatus.FORBIDDEN);
+    USER_SUSPENDED("USER005", "정지된 사용자입니다.", HttpStatus.FORBIDDEN),
+
+    // 상품/조회 에러
+    PRODUCT_NOT_FOUND("PRODUCT001","상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
     
     private final String code;
     private final String message;

--- a/main-server/src/main/java/com/freedom/common/exception/GlobalExceptionHandler.java
+++ b/main-server/src/main/java/com/freedom/common/exception/GlobalExceptionHandler.java
@@ -18,93 +18,93 @@ import java.util.List;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    
+
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleUserNotFoundException(UserNotFoundException e) {
         log.warn("사용자를 찾을 수 없음: {}", e.getMessage());
         return createErrorResponse(ErrorCode.USER_NOT_FOUND);
     }
-    
+
     @ExceptionHandler(DuplicateEmailException.class)
     public ResponseEntity<ErrorResponse> handleDuplicateEmailException(DuplicateEmailException e) {
         log.warn("이메일 중복: {}", e.getMessage());
         return createErrorResponse(ErrorCode.DUPLICATE_EMAIL);
     }
-    
+
     @ExceptionHandler(InvalidPasswordException.class)
     public ResponseEntity<ErrorResponse> handleInvalidPasswordException(InvalidPasswordException e) {
         log.warn("비밀번호 불일치: {}", e.getMessage());
         return createErrorResponse(ErrorCode.INVALID_PASSWORD);
     }
-    
+
     @ExceptionHandler(UserWithdrawnException.class)
     public ResponseEntity<ErrorResponse> handleUserWithdrawnException(UserWithdrawnException e) {
         log.warn("탈퇴한 사용자 접근: {}", e.getMessage());
         return createErrorResponse(ErrorCode.USER_WITHDRAWN);
     }
-    
+
     @ExceptionHandler(UserSuspendedException.class)
     public ResponseEntity<ErrorResponse> handleUserSuspendedException(UserSuspendedException e) {
         log.warn("정지된 사용자 접근: {}", e.getMessage());
         return createErrorResponse(ErrorCode.USER_SUSPENDED);
     }
-    
+
     @ExceptionHandler(TokenExpiredException.class)
     public ResponseEntity<ErrorResponse> handleTokenExpiredException(TokenExpiredException e) {
         log.warn("토큰 만료: {}", e.getMessage());
         return createErrorResponse(ErrorCode.TOKEN_EXPIRED);
     }
-    
+
     @ExceptionHandler(TokenInvalidException.class)
     public ResponseEntity<ErrorResponse> handleTokenInvalidException(TokenInvalidException e) {
         log.warn("유효하지 않은 토큰: {}", e.getMessage());
         return createErrorResponse(ErrorCode.TOKEN_INVALID);
     }
-    
+
     @ExceptionHandler(RefreshTokenExpiredException.class)
     public ResponseEntity<ErrorResponse> handleRefreshTokenExpiredException(RefreshTokenExpiredException e) {
         log.warn("리프레시 토큰 만료: {}", e.getMessage());
         return createErrorResponse(ErrorCode.REFRESH_TOKEN_EXPIRED);
     }
-    
+
     @ExceptionHandler(RefreshTokenInvalidException.class)
     public ResponseEntity<ErrorResponse> handleRefreshTokenInvalidException(RefreshTokenInvalidException e) {
         log.warn("유효하지 않은 리프레시 토큰: {}", e.getMessage());
         return createErrorResponse(ErrorCode.REFRESH_TOKEN_INVALID);
     }
-    
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ValidationErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.warn("유효성 검증 실패: {}", e.getBindingResult().getAllErrors());
-        
+
         List<ValidationFieldError> fieldErrors = e.getBindingResult()
                 .getFieldErrors()
                 .stream()
                 .map(this::mapToValidationFieldError)
                 .toList();
-        
+
         ValidationErrorResponse errorResponse = ValidationErrorResponse.of(ErrorCode.VALIDATION_ERROR, fieldErrors);
         return ResponseEntity
                 .status(ErrorCode.VALIDATION_ERROR.getStatus())
                 .body(errorResponse);
     }
-    
+
     @ExceptionHandler(BindException.class)
     public ResponseEntity<ValidationErrorResponse> handleBindException(BindException e) {
         log.warn("바인딩 예외: {}", e.getBindingResult().getAllErrors());
-        
+
         List<ValidationFieldError> fieldErrors = e.getBindingResult()
                 .getFieldErrors()
                 .stream()
                 .map(this::mapToValidationFieldError)
                 .toList();
-        
+
         ValidationErrorResponse errorResponse = ValidationErrorResponse.of(ErrorCode.VALIDATION_ERROR, fieldErrors);
         return ResponseEntity
                 .status(ErrorCode.VALIDATION_ERROR.getStatus())
                 .body(errorResponse);
     }
-    
+
     /**
      * FieldError를 ValidationFieldError로 변환하는 메서드
      */
@@ -116,7 +116,7 @@ public class GlobalExceptionHandler {
                 fieldError.getDefaultMessage()
         );
     }
-    
+
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
         log.warn("지원하지 않는 HTTP 메서드: {}", e.getMessage());
@@ -146,5 +146,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(errorResponse);
+    }
+
+    @ExceptionHandler(SavingProductNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleSavingProductNotFoundException(SavingProductNotFoundException e) {
+        log.warn("상품을 찾을 수 없음: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.PRODUCT_NOT_FOUND.getStatus())
+                .body(ErrorResponse.of(ErrorCode.PRODUCT_NOT_FOUND));
+
     }
 }

--- a/main-server/src/main/java/com/freedom/common/exception/custom/SavingProductNotFoundException.java
+++ b/main-server/src/main/java/com/freedom/common/exception/custom/SavingProductNotFoundException.java
@@ -1,0 +1,7 @@
+package com.freedom.common.exception.custom;
+
+public class SavingProductNotFoundException extends RuntimeException {
+  public SavingProductNotFoundException(Long id) {
+    super("적금 상품 스냅샷을 찾을 수 없습니다. id = " + id);
+  }
+}

--- a/main-server/src/main/java/com/freedom/saving/api/SavingProductReadController.java
+++ b/main-server/src/main/java/com/freedom/saving/api/SavingProductReadController.java
@@ -1,0 +1,51 @@
+package com.freedom.saving.api;
+
+import com.freedom.saving.application.SavingProductReadService;
+import com.freedom.saving.application.read.SavingProductDetail;
+import com.freedom.saving.application.read.SavingProductListItem;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import org.springframework.data.domain.Page;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Validated
+@RestController
+@RequestMapping("/api/products")
+public class SavingProductReadController {
+
+    private final SavingProductReadService readService;
+
+    public SavingProductReadController(SavingProductReadService readService) {
+        this.readService = readService;
+    }
+
+    @GetMapping
+    public Page<SavingProductListItem> getProducts(
+            // 타입은 현재 SAVING만 지원. 추후 예/적금 분리 시 확장 포인트.
+            @RequestParam(name = "type", defaultValue = "SAVING") @NotBlank String type,
+            // 정렬 정책 키. 현재 popular(임시)만 허용.
+            @RequestParam(name = "sort", defaultValue = "popular") String sort,
+            @RequestParam(name = "page", defaultValue = "0") @Min(0) int page,
+            @RequestParam(name = "size", defaultValue = "20") @Min(1) @Max(100) int size) {
+
+        // 아직 SAVING만 지원하므로 방어적으로 검증
+        if (!"SAVING".equalsIgnoreCase(type)) {
+            throw new IllegalArgumentException("지원하지 않는 type 값입니다. (허용: SAVING)");
+        }
+        // popular 외 값이 들어오면 현재 동작과 다른 결과가 나올 수 있어 방어적으로 검증
+        if (!"popular".equalsIgnoreCase(sort)) {
+            throw new IllegalArgumentException("지원하지 않는 sort 값입니다. (허용: popular)");
+        }
+        // 서비스는 인기순(임시) = fetchedAt DESC 정렬로 페이지 결과 제공
+        return readService.getPopularSavingProducts(page, size);
+    }
+
+    @GetMapping("/{id}")
+    public SavingProductDetail getProductDetail(
+            @PathVariable("id") @Positive Long productSnapshotId) {
+        return readService.getDetail(productSnapshotId);
+    }
+}

--- a/main-server/src/main/java/com/freedom/saving/application/SavingProductReadService.java
+++ b/main-server/src/main/java/com/freedom/saving/application/SavingProductReadService.java
@@ -1,0 +1,122 @@
+package com.freedom.saving.application;
+
+import com.freedom.common.exception.custom.SavingProductNotFoundException;
+import com.freedom.saving.application.read.SavingProductDetail;
+import com.freedom.saving.application.read.SavingProductListItem;
+import com.freedom.saving.application.read.SavingProductOptionItem;
+import com.freedom.saving.domain.SavingProductOptionSnapshot;
+import com.freedom.saving.domain.SavingProductSnapshot;
+import com.freedom.saving.infra.snapshot.SavingProductOptionSnapshotJpaRepository;
+import com.freedom.saving.infra.snapshot.SavingProductSnapshotJpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 읽기 전용 유스케이스: 상품 목록/상세 조회
+ * 도메인 엔티티를 외부로 직접 노출하지 않고, application DTO(SavingProductListItem/Detail)로 매핑해 반환
+ */
+@Service
+@Transactional(readOnly = true)
+public class SavingProductReadService {
+
+    private final SavingProductSnapshotJpaRepository productRepo;
+    private final SavingProductOptionSnapshotJpaRepository optionRepo;
+
+    public SavingProductReadService(SavingProductSnapshotJpaRepository productRepo,
+                                    SavingProductOptionSnapshotJpaRepository optionRepo) {
+        this.productRepo = productRepo;
+        this.optionRepo = optionRepo;
+    }
+
+    /**
+     * [목록] 인기순 적금 상품 조회
+     *
+     * 현재: 가입 수 집계가 준비되지 않아 임시로 fetchedAt DESC(최신 수집 순) 사용
+     * 추후: 가입 수 기반 정렬로 교체
+     *
+     * @param page 0-base 페이지 번호
+     * @param size 페이지 크기
+     * @return SavingProductListItem Page
+     */
+    public Page<SavingProductListItem> getPopularSavingProducts(int page, int size) {
+        // 임시 인기순: 최신 스냅샷 우선
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "fetchedAt"));
+
+        // 1) 최신 스냅샷 페이징 엔티티 조회
+        Page<SavingProductSnapshot> pageResult = productRepo.findByIsLatestTrue(pageable);
+
+        // 2) 엔티티 -> 목록 DTO 수작업 매핑
+        List<SavingProductSnapshot> contents = pageResult.getContent();
+        List<SavingProductListItem> items = new ArrayList<SavingProductListItem>();
+        for (SavingProductSnapshot s : contents) {
+            SavingProductListItem item = new SavingProductListItem();
+            item.setProductSnapshotId(s.getId());
+            item.setProductName(s.getFinPrdtNm());
+            item.setBankName(s.getKorCoNm());
+
+            // DTO에 해당 필드가 아직 존재한다면 null/빈값으로 둔다.
+            item.setAiSummary(""); // 추후 AI 요약이 준비되면 주입
+
+            items.add(item);
+        }
+
+        // 3) Page 래핑 반환
+        return new PageImpl<SavingProductListItem>(items, pageable, pageResult.getTotalElements());
+    }
+
+    /**
+     * [상세] 상품 1건 상세 조회(헤더 + 옵션 목록)
+     */
+    public SavingProductDetail getDetail(Long productSnapshotId) {
+        // 1) 스냅샷 단건 조회
+        Optional<SavingProductSnapshot> optional = productRepo.findById(productSnapshotId);
+        if (!optional.isPresent()) {
+            throw new SavingProductNotFoundException(productSnapshotId);
+        }
+        SavingProductSnapshot s = optional.get();
+
+        // 2) 옵션 목록 조회
+        List<SavingProductOptionSnapshot> options =
+                optionRepo.findByProductSnapshotIdOrderBySaveTrmMonthsAsc(productSnapshotId);
+
+        // 3) 엔티티 -> 상세 DTO 매핑
+        SavingProductDetail detail = new SavingProductDetail();
+        detail.setProductSnapshotId(s.getId());
+        detail.setProductName(s.getFinPrdtNm());
+        detail.setBankName(s.getKorCoNm());
+        detail.setJoinWay(s.getJoinWay());
+        detail.setSpecialCondition(s.getSpclCnd());
+        detail.setJoinDeny(s.getJoinDeny());
+        detail.setJoinMember(s.getJoinMember());
+        detail.setEtcNote(s.getEtcNote());
+        detail.setFetchedAt(s.getFetchedAt());
+
+        detail.setAiSummary(""); // 자리만 확보(추후 요약/설명 주입)
+
+        List<SavingProductOptionItem> optionItems = new ArrayList<SavingProductOptionItem>();
+        for (SavingProductOptionSnapshot o : options) {
+            SavingProductOptionItem oi = new SavingProductOptionItem();
+            oi.setTermMonths(o.getSaveTrmMonths());
+            oi.setRate(o.getIntrRate());
+            oi.setRatePreferential(o.getIntrRate2());
+            oi.setRateType(o.getIntrRateType());
+            oi.setRateTypeName(o.getIntrRateTypeNm());
+            oi.setReserveType(o.getRsrvType());
+            oi.setReserveTypeName(o.getRsrvTypeNm());
+
+            optionItems.add(oi);
+        }
+        detail.setOptions(optionItems);
+
+        return detail;
+    }
+}

--- a/main-server/src/main/java/com/freedom/saving/application/bootstrap/FssManualBootstrapConfig.java
+++ b/main-server/src/main/java/com/freedom/saving/application/bootstrap/FssManualBootstrapConfig.java
@@ -1,0 +1,241 @@
+package com.freedom.saving.application.bootstrap;
+
+import com.freedom.common.time.TimeProvider;
+import com.freedom.saving.domain.SavingProductOptionSnapshot;
+import com.freedom.saving.domain.SavingProductSnapshot;
+import com.freedom.saving.domain.shapshot.SavingProductOptionSnapshotDraft;
+import com.freedom.saving.domain.shapshot.SavingProductSnapshotDraft;
+import com.freedom.saving.infra.fss.FssSavingApiClient;
+import com.freedom.saving.infra.fss.FssSavingResponseDto;
+import com.freedom.saving.infra.snapshot.SavingProductOptionSnapshotJpaRepository;
+import com.freedom.saving.infra.snapshot.SavingProductSnapshotJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 로컬/개발에서 FSS(020000: 은행권) 적금 상품 스냅샷 1회 적재 Runner
+ * - app.fss.bootstrap-enabled=true 일 때만 동작
+ * - 중복 방지: (dcls_month, fin_co_no, fin_prdt_cd)
+ * - 최신 토글: (fin_co_no, fin_prdt_cd) 단위로 is_latest=true 1건 유지
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class FssManualBootstrapConfig {
+
+    private final FssSavingApiClient fssClient;
+    private final SavingProductSnapshotJpaRepository productRepo;
+    private final SavingProductOptionSnapshotJpaRepository optionRepo;
+    private final PlatformTransactionManager txManager;
+    private final TimeProvider timeProvider;
+
+    @Value("${app.fss.bootstrap-enabled:false}")
+    private boolean enabled;
+
+    @Bean
+    ApplicationRunner fssBootstrapRunner() {
+        return args -> {
+            if (!enabled) {
+                log.info("[FSS-BOOTSTRAP] disabled. skip.");
+                return;
+            }
+
+            final String group = "020000"; // 은행권만 수집
+            int page = 1;
+
+            log.info("[FSS-BOOTSTRAP] start group={}", group);
+
+            while (true) {
+                FssSavingResponseDto dto;
+                try {
+                    // Runner에서만 block() 사용 (웹 요청 스레드 아님)
+                    dto = fssClient.fetchSavings(group, page).block();
+                } catch (Exception e) {
+                    log.error("[FSS-BOOTSTRAP] fetch error. page={}", page, e);
+                    break;
+                }
+
+                if (dto == null || dto.result == null) {
+                    log.warn("[FSS-BOOTSTRAP] empty result at page={}", page);
+                    break;
+                }
+
+                Integer nowPage = dto.result.nowPageNo;
+                Integer maxPage = dto.result.maxPageNo;
+                int baseCnt = dto.result.baseList == null ? 0 : dto.result.baseList.size();
+                int optCnt  = dto.result.optionList == null ? 0 : dto.result.optionList.size();
+                log.info("[FSS-BOOTSTRAP] page {}/{}: base={}, option={}", nowPage, maxPage, baseCnt, optCnt);
+
+                // 이번 페이지에서 "신규로 저장된" 스냅샷 id를 (finCoNo|finPrdtCd) 키로 보관
+                Map<String, Long> newSnapshotIdByKey = new HashMap<String, Long>();
+
+                // 1) baseList → 스냅샷 저장 (중복 방지 + 최신 토글)
+                if (dto.result.baseList != null) {
+                    for (int i = 0; i < dto.result.baseList.size(); i++) {
+                        FssSavingResponseDto.Base b = dto.result.baseList.get(i);
+                        if (b == null) continue;
+                        if (b.dclsMonth == null || b.finCoNo == null || b.finPrdtCd == null) continue;
+
+                        boolean exists;
+                        try {
+                            exists = productRepo.existsByDclsMonthAndFinCoNoAndFinPrdtCd(
+                                    b.dclsMonth, b.finCoNo, b.finPrdtCd
+                            );
+                        } catch (Exception ex) {
+                            log.error("[FSS-BOOTSTRAP] exists check fail ({},{},{}) idx={}",
+                                    b.dclsMonth, b.finCoNo, b.finPrdtCd, i, ex);
+                            continue;
+                        }
+                        if (exists) {
+                            // 동일 공시월/회사/상품 스냅샷 이미 존재 → skip
+                            log.debug("[FSS-BOOTSTRAP] duplicate skip ({},{},{})", b.dclsMonth, b.finCoNo, b.finPrdtCd);
+                            continue;
+                        }
+
+                        // Draft(불변 VO) 생성 → 엔티티 정적 팩토리로 변환
+                        SavingProductSnapshotDraft draft = new SavingProductSnapshotDraft(
+                                b.dclsMonth,
+                                b.finCoNo,
+                                b.finPrdtCd,
+                                b.korCoNm,
+                                b.finPrdtNm,
+                                b.joinWay,
+                                b.mtrtInt,
+                                b.spclCnd,
+                                b.joinDeny,
+                                b.joinMember,
+                                b.etcNote,
+                                b.maxLimit,
+                                b.dclsStrtDay,
+                                b.dclsEndDay,
+                                b.finCoSubmDay
+                        );
+
+                        final String key = buildKey(b.finCoNo, b.finPrdtCd);
+                        // TimeProvider(ZonedDateTime) → LocalDateTime
+                        final LocalDateTime fetchedAt =
+                                (timeProvider == null
+                                        ? java.time.ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
+                                        : timeProvider.now())
+                                        .toLocalDateTime();
+
+                        // 트랜잭션: 최신 토글 해제 → from(draft,true,fetchedAt) 저장
+                        TransactionTemplate tt = new TransactionTemplate(txManager);
+                        Long savedId = tt.execute(new TransactionCallback<Long>() {
+                            @Override
+                            public Long doInTransaction(TransactionStatus status) {
+                                productRepo.clearLatest(b.finCoNo, b.finPrdtCd); // 기존 최신 해제
+                                SavingProductSnapshot entity = SavingProductSnapshot.from(draft, true, fetchedAt);
+                                SavingProductSnapshot saved = productRepo.save(entity);
+                                return saved.getId();
+                            }
+                        });
+
+                        if (savedId != null) {
+                            newSnapshotIdByKey.put(key, savedId);
+                        }
+                    }
+                }
+
+                // 2) optionList → 방금 저장된 스냅샷에만 옵션 저장
+                if (dto.result.optionList != null && !newSnapshotIdByKey.isEmpty()) {
+                    for (int i = 0; i < dto.result.optionList.size(); i++) {
+                        FssSavingResponseDto.Option o = dto.result.optionList.get(i);
+                        if (o == null) continue;
+                        if (o.finCoNo == null || o.finPrdtCd == null) continue;
+
+                        String key = buildKey(o.finCoNo, o.finPrdtCd);
+                        Long snapshotId = newSnapshotIdByKey.get(key);
+                        if (snapshotId == null) {
+                            // 이번 페이지에서 신규 저장되지 않은 상품의 옵션은 skip (중복 적재 방지)
+                            continue;
+                        }
+
+                        Integer termMonths = parseIntSafe(o.saveTrm);
+                        BigDecimal rate = toBigDecimal(o.intrRate);
+                        BigDecimal ratePreferential = toBigDecimal(o.intrRate2);
+
+                        // Draft 생성 → 엔티티 정적 팩토리로 변환
+                        SavingProductOptionSnapshotDraft optDraft = new SavingProductOptionSnapshotDraft(
+                                o.dclsMonth,
+                                o.finCoNo,
+                                o.finPrdtCd,
+                                o.intrRateType,
+                                o.intrRateTypeNm,
+                                o.rsrvType,
+                                o.rsrvTypeNm,
+                                termMonths,
+                                rate,
+                                ratePreferential
+                        );
+
+                        // 트랜잭션: 옵션 1건 저장
+                        TransactionTemplate tt = new TransactionTemplate(txManager);
+                        tt.execute(new TransactionCallbackWithoutResult() {
+                            @Override
+                            protected void doInTransactionWithoutResult(TransactionStatus status) {
+                                SavingProductOptionSnapshot opt =
+                                        SavingProductOptionSnapshot.from(optDraft, snapshotId);
+                                optionRepo.save(opt);
+                            }
+                        });
+                    }
+                }
+
+                // 다음 페이지로
+                if (maxPage == null || nowPage == null || nowPage.intValue() >= maxPage.intValue()) {
+                    break;
+                }
+                page++;
+            }
+
+            log.info("[FSS-BOOTSTRAP] finished group={}", group);
+        };
+    }
+
+    private String buildKey(String finCoNo, String finPrdtCd) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(finCoNo == null ? "" : finCoNo);
+        sb.append('|');
+        sb.append(finPrdtCd == null ? "" : finPrdtCd);
+        return sb.toString();
+    }
+
+    /**
+     * 문자열 숫자 방어적 파싱(FSS saveTrm이 문자열이라 숫자 외 문자가 들어올 가능성 대비)
+     */
+    private Integer parseIntSafe(String s) {
+        if (s == null) return null;
+        int len = s.length();
+        if (len == 0) return null;
+        for (int i = 0; i < len; i++) {
+            char c = s.charAt(i);
+            if (c < '0' || c > '9') return null;
+        }
+        try {
+            return Integer.parseInt(s);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private BigDecimal toBigDecimal(Double d) {
+        if (d == null) return null;
+        return BigDecimal.valueOf(d.doubleValue());
+    }
+}

--- a/main-server/src/main/java/com/freedom/saving/application/read/SavingProductDetail.java
+++ b/main-server/src/main/java/com/freedom/saving/application/read/SavingProductDetail.java
@@ -1,0 +1,47 @@
+package com.freedom.saving.application.read;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 상세 응답용 dto
+ */
+public class SavingProductDetail {
+
+    private Long productSnapshotId;
+    private String productName;
+    private String bankName;
+    private String joinWay;
+    private String specialCondition;
+    private String joinDeny;
+    private String joinMember;
+    private String etcNote;
+    private String aiSummary; // 자리만 확보
+    private LocalDateTime fetchedAt;
+    private List<SavingProductOptionItem> options = new ArrayList<SavingProductOptionItem>();
+
+    public Long getProductSnapshotId() { return productSnapshotId; }
+    public String getProductName() { return productName; }
+    public String getBankName() { return bankName; }
+    public String getJoinWay() { return joinWay; }
+    public String getSpecialCondition() { return specialCondition; }
+    public String getJoinDeny() { return joinDeny; }
+    public String getJoinMember() { return joinMember; }
+    public String getEtcNote() { return etcNote; }
+    public String getAiSummary() { return aiSummary; }
+    public LocalDateTime getFetchedAt() { return fetchedAt; }
+    public List<SavingProductOptionItem> getOptions() { return options; }
+
+    public void setProductSnapshotId(Long productSnapshotId) { this.productSnapshotId = productSnapshotId; }
+    public void setProductName(String productName) { this.productName = productName; }
+    public void setBankName(String bankName) { this.bankName = bankName; }
+    public void setJoinWay(String joinWay) { this.joinWay = joinWay; }
+    public void setSpecialCondition(String specialCondition) { this.specialCondition = specialCondition; }
+    public void setJoinDeny(String joinDeny) { this.joinDeny = joinDeny; }
+    public void setJoinMember(String joinMember) { this.joinMember = joinMember; }
+    public void setEtcNote(String etcNote) { this.etcNote = etcNote; }
+    public void setAiSummary(String aiSummary) { this.aiSummary = aiSummary; }
+    public void setFetchedAt(LocalDateTime fetchedAt) { this.fetchedAt = fetchedAt; }
+    public void setOptions(List<SavingProductOptionItem> options) { this.options = options; }
+}

--- a/main-server/src/main/java/com/freedom/saving/application/read/SavingProductListItem.java
+++ b/main-server/src/main/java/com/freedom/saving/application/read/SavingProductListItem.java
@@ -1,0 +1,27 @@
+package com.freedom.saving.application.read;
+
+import java.math.BigDecimal;
+
+/**
+ * 목록 응답용 dto
+ * 엔티티를 직접 노출하지 않고 필요한 필드만 담기
+ */
+public class SavingProductListItem {
+    private Long productSnapshotId;
+    private String productName;
+    private String bankName;
+    private BigDecimal bestRate; // 페이지 내 일괄 집계해서 채움
+    private String aiSummary;    // 자리만 확보
+
+    public Long getProductSnapshotId() { return productSnapshotId; }
+    public String getProductName() { return productName; }
+    public String getBankName() { return bankName; }
+    public BigDecimal getBestRate() { return bestRate; }
+    public String getAiSummary() { return aiSummary; }
+
+    public void setProductSnapshotId(Long productSnapshotId) { this.productSnapshotId = productSnapshotId; }
+    public void setProductName(String productName) { this.productName = productName; }
+    public void setBankName(String bankName) { this.bankName = bankName; }
+    public void setBestRate(BigDecimal bestRate) { this.bestRate = bestRate; }
+    public void setAiSummary(String aiSummary) { this.aiSummary = aiSummary; }
+}

--- a/main-server/src/main/java/com/freedom/saving/application/read/SavingProductOptionItem.java
+++ b/main-server/src/main/java/com/freedom/saving/application/read/SavingProductOptionItem.java
@@ -1,0 +1,33 @@
+package com.freedom.saving.application.read;
+
+import java.math.BigDecimal;
+
+/**
+ * 상세 옵션(기간/금리) dto
+ */
+public class SavingProductOptionItem {
+
+    private Integer termMonths;
+    private BigDecimal rate;
+    private BigDecimal ratePreferential;
+    private String rateType;
+    private String rateTypeName;
+    private String reserveType;
+    private String reserveTypeName;
+
+    public Integer getTermMonths() { return termMonths; }
+    public BigDecimal getRate() { return rate; }
+    public BigDecimal getRatePreferential() { return ratePreferential; }
+    public String getRateType() { return rateType; }
+    public String getRateTypeName() { return rateTypeName; }
+    public String getReserveType() { return reserveType; }
+    public String getReserveTypeName() { return reserveTypeName; }
+
+    public void setTermMonths(Integer termMonths) { this.termMonths = termMonths; }
+    public void setRate(BigDecimal rate) { this.rate = rate; }
+    public void setRatePreferential(BigDecimal ratePreferential) { this.ratePreferential = ratePreferential; }
+    public void setRateType(String rateType) { this.rateType = rateType; }
+    public void setRateTypeName(String rateTypeName) { this.rateTypeName = rateTypeName; }
+    public void setReserveType(String reserveType) { this.reserveType = reserveType; }
+    public void setReserveTypeName(String reserveTypeName) { this.reserveTypeName = reserveTypeName; }
+}

--- a/main-server/src/main/java/com/freedom/saving/infra/snapshot/SavingProductSnapshotJpaRepository.java
+++ b/main-server/src/main/java/com/freedom/saving/infra/snapshot/SavingProductSnapshotJpaRepository.java
@@ -1,6 +1,8 @@
 package com.freedom.saving.infra.snapshot;
 
 import com.freedom.saving.domain.SavingProductSnapshot;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -38,4 +40,10 @@ public interface SavingProductSnapshotJpaRepository extends JpaRepository<Saving
             "set s.isLatest = false " +
             "where s.finCoNo = :finCoNo and s.finPrdtCd = :finPrdtCd and s.isLatest = true")
     int clearLatest(@Param("finCoNo") String finCoNo, @Param("finPrdtCd") String finPrdtCd);
+
+    /**
+     * 최신 스냅샷만 페이지 조회
+     * 정렬은 Pageable의 Sort를 따른다
+     */
+    Page<SavingProductSnapshot> findByIsLatestTrue(Pageable pageable);
 }

--- a/main-server/src/main/resources/application.yml
+++ b/main-server/src/main/resources/application.yml
@@ -39,3 +39,7 @@ fss:
 jobs:
   fss-sync:
     enabled: true
+
+app:
+  fss:
+    bootstrap-enabled: false   #  켜두면 기동 시 1회 실행

--- a/main-server/src/test/java/com/freedom/saving/api/SavingProductReadControllerTest.java
+++ b/main-server/src/test/java/com/freedom/saving/api/SavingProductReadControllerTest.java
@@ -1,0 +1,160 @@
+package com.freedom.saving.api;
+
+import com.freedom.common.exception.GlobalExceptionHandler;
+import com.freedom.common.exception.custom.SavingProductNotFoundException;
+import com.freedom.saving.application.SavingProductReadService;
+import com.freedom.saving.application.read.SavingProductDetail;
+import com.freedom.saving.application.read.SavingProductListItem;
+import com.freedom.saving.application.read.SavingProductOptionItem;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * 컨트롤러 슬라이스 테스트
+ * - @WebMvcTest: MVC 레이어만 로드하여 빠르고 독립적으로 검증
+ * - @MockBean: 애플리케이션 서비스 스텁 주입
+ * - @Import(GlobalExceptionHandler): 전역 예외 포맷/상태코드 검증을 위해 명시 등록
+ *
+ * 케이스
+ *  1) 목록 200: /api/products?type=SAVING&sort=popular&page=0&size=2
+ *  2) 검증 400: page가 음수일 때 @Min(0) 위반 → 400 + Validation 에러 포맷
+ *  3) 상세 200: /api/products/{id}
+ *  4) 상세 404: 서비스가 SavingProductNotFoundException 던질 때 PRODUCT001(404) 매핑
+ */
+@WebMvcTest(
+        controllers = SavingProductReadController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(
+                        type = org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE,
+                        classes = com.freedom.common.config.SecurityConfig.class // 시큐리티 구성 제외
+                ),
+                @ComponentScan.Filter(
+                        type = org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE,
+                        classes = com.freedom.common.security.JwtAuthenticationFilter.class // JWT 필터 제외
+                ),
+                @ComponentScan.Filter(
+                        type = org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE
+                )
+        }
+)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandler.class)
+class SavingProductReadControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private SavingProductReadService readService;
+
+    @Test
+    @DisplayName("목록 200 - 인기순(임시:fetchedAt DESC) 페이지 반환")
+    void list_popular_success_200() throws Exception {
+        SavingProductListItem item = new SavingProductListItem();
+        item.setProductSnapshotId(10L);
+        item.setProductName("적금A");
+        item.setBankName("은행A");
+        item.setAiSummary("");
+
+        Mockito.when(readService.getPopularSavingProducts(0, 2))
+                .thenReturn(new PageImpl<>(
+                        Collections.singletonList(item),
+                        org.springframework.data.domain.PageRequest.of(0, 2),
+                        1
+                ));
+
+        mockMvc.perform(get("/api/products")
+                        .param("type", "SAVING")
+                        .param("sort", "popular")
+                        .param("page", "0")
+                        .param("size", "2")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.content[0].productSnapshotId", is(10)))
+                .andExpect(jsonPath("$.content[0].productName", is("적금A")))
+                .andExpect(jsonPath("$.content[0].bankName", is("은행A")));
+    }
+
+    @Test
+    @DisplayName("목록 400 - page가 음수이면 @Min(0) 위반으로 400")
+    void list_validation_error_page_negative_400() throws Exception {
+        mockMvc.perform(get("/api/products")
+                        .param("type", "SAVING")
+                        .param("sort", "popular")
+                        .param("page", "-1")
+                        .param("size", "20")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code", is("VALIDATION001")))
+                .andExpect(jsonPath("$.errors", notNullValue()))
+                .andExpect(jsonPath("$.errors[0].field", is("page")))
+                .andExpect(jsonPath("$.errors[0].code", is("Min")));
+    }
+
+    @Test
+    @DisplayName("상세 200 - 헤더 + 옵션 목록 반환")
+    void detail_success_200() throws Exception {
+        SavingProductDetail detail = new SavingProductDetail();
+        detail.setProductSnapshotId(123L);
+        detail.setProductName("적금A");
+        detail.setBankName("은행A");
+        detail.setJoinWay("인터넷");
+        detail.setSpecialCondition("우대 없음");
+        detail.setJoinDeny("1");
+        detail.setJoinMember("제한 없음");
+        detail.setEtcNote("");
+        detail.setFetchedAt(LocalDateTime.now());
+        detail.setAiSummary("");
+
+        SavingProductOptionItem opt = new SavingProductOptionItem();
+        opt.setTermMonths(12);
+        opt.setRate(new BigDecimal("3.20"));
+        opt.setRatePreferential(new BigDecimal("3.50"));
+        opt.setRateType("S");
+        opt.setRateTypeName("단리");
+        opt.setReserveType("F");
+        opt.setReserveTypeName("자유적립");
+        detail.setOptions(Arrays.asList(opt));
+
+        Mockito.when(readService.getDetail(123L)).thenReturn(detail);
+
+        mockMvc.perform(get("/api/products/{id}", 123L).accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.productSnapshotId", is(123)))
+                .andExpect(jsonPath("$.productName", is("적금A")))
+                .andExpect(jsonPath("$.bankName", is("은행A")))
+                .andExpect(jsonPath("$.options", hasSize(1)))
+                .andExpect(jsonPath("$.options[0].termMonths", is(12)));
+    }
+
+    @Test
+    @DisplayName("상세 404 - 존재하지 않는 ID면 PRODUCT001 반환")
+    void detail_not_found_404() throws Exception {
+        Mockito.when(readService.getDetail(999L))
+                .thenThrow(new SavingProductNotFoundException(999L));
+
+        mockMvc.perform(get("/api/products/{id}", 999L).accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code", is("PRODUCT001")));
+    }
+}


### PR DESCRIPTION
## FSS 스냅샷을 데이터 소스로 하는 적금 상품 조회(목록/상세) API 추가
- - -
### Application
- `SavingProductReadService` 도입
   - 최신 스냅샷(`is_latest = true`) 기준 목록 조회(임시 인기순 = fetchedAt DESC)
- DTO
   - `SavingProductListItem` : 목록 카드용 최소 정보
   - `SavingProductDetail` : 상세 헤더 정보 + `options[]`
   - `SavingProductOptionItem` : 기간/금리/유형
 
### API
- `GET /api/products?type=SAVING&sort=popular&page=0&size=20`
- `GET /api/products/{id}`
- - -

## 추후 도입 사항
- 인기순 정렬
- 검색 옵션