### PR TITLE
Quest 기능 구현

### DIFF
--- a/main-server/src/main/java/com/freedom/attendance/domain/service/AttendanceReadService.java
+++ b/main-server/src/main/java/com/freedom/attendance/domain/service/AttendanceReadService.java
@@ -37,4 +37,10 @@ public class AttendanceReadService {
                 .forEach(a -> map[a.getCheckDate().getDayOfMonth() - 1] = true);
         return map;
     }
+
+    @Transactional(readOnly = true)
+    public boolean wasAttendedYesterday(Long userId) {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        return attendanceRepository.existsByUserIdAndCheckDate(userId, yesterday);
+    }
 }

--- a/main-server/src/main/java/com/freedom/attendance/infra/AttendanceRepository.java
+++ b/main-server/src/main/java/com/freedom/attendance/infra/AttendanceRepository.java
@@ -10,4 +10,6 @@ import java.util.List;
 @Repository
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
     List<Attendance> findAllByUserIdAndCheckDateBetween(Long userId, LocalDate start, LocalDate end);
+
+    boolean existsByUserIdAndCheckDate(Long userId, LocalDate yesterday);
 }

--- a/main-server/src/main/java/com/freedom/auth/application/AuthFacade.java
+++ b/main-server/src/main/java/com/freedom/auth/application/AuthFacade.java
@@ -8,6 +8,7 @@ import com.freedom.auth.domain.User;
 import com.freedom.auth.domain.service.*;
 import com.freedom.common.logging.Loggable;
 import com.freedom.common.security.JwtProvider;
+import com.freedom.wallet.application.WalletService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -24,6 +25,7 @@ public class AuthFacade {
     private final ValidateUserService validateUserService;
     private final RefreshTokenService refreshTokenService;
     private final CharacterNameService characterNameService;
+    private final WalletService walletService;
     private final JwtProvider jwtProvider;
     
     @Value("${jwt.access-token.expiration}")
@@ -71,7 +73,9 @@ public class AuthFacade {
     @Loggable("캐릭터 이름 생성 처리")
     @Transactional
     public String createCharacterName(Long userId, String characterName) {
-        return characterNameService.createCharacterName(userId, characterName);
+        String chracterName = characterNameService.createCharacterName(userId, characterName);
+        walletService.createWallet(userId);
+        return chracterName;
     }
 
     private TokenDto createTokenResponse(User user) {

--- a/main-server/src/main/java/com/freedom/auth/domain/UserRole.java
+++ b/main-server/src/main/java/com/freedom/auth/domain/UserRole.java
@@ -1,13 +1,11 @@
 package com.freedom.auth.domain;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 /**
  * 사용자 권한 열거형
  */
 @Getter
-@RequiredArgsConstructor
 public enum UserRole {
     
     USER("ROLE_USER", "일반 사용자"),
@@ -15,4 +13,9 @@ public enum UserRole {
     
     private final String authority;
     private final String description;
+    
+    UserRole(String authority, String description) {
+        this.authority = authority;
+        this.description = description;
+    }
 }

--- a/main-server/src/main/java/com/freedom/auth/domain/UserStatus.java
+++ b/main-server/src/main/java/com/freedom/auth/domain/UserStatus.java
@@ -1,10 +1,8 @@
 package com.freedom.auth.domain;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public enum UserStatus {
     
     ACTIVE("활성", "정상적으로 서비스를 이용할 수 있는 상태"),
@@ -13,4 +11,9 @@ public enum UserStatus {
     
     private final String displayName;
     private final String description;
+    
+    UserStatus(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
 }

--- a/main-server/src/main/java/com/freedom/common/exception/ErrorCode.java
+++ b/main-server/src/main/java/com/freedom/common/exception/ErrorCode.java
@@ -63,6 +63,14 @@ public enum ErrorCode {
     SAVING_DUPLICATE_SUBSCRIPTION("SAV009", "이미 가입한 적금에 또 가입할 수 없습니다.", HttpStatus.BAD_REQUEST),
     SAVING_NO_TODAY_PAYABLE("SAV010", "오늘 납입 가능한 회차가 없습니다.", HttpStatus.BAD_REQUEST),
 
+    // 퀘스트 에러
+    USER_QUEST_NOT_FOUND("QUEST001", "사용자 퀘스트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    USER_WALLET_NOT_FOUND("QUEST002", "사용자 지갑을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    QUEST_ALREADY_COMPLETED("QUEST003", "이미 완료된 퀘스트입니다.", HttpStatus.BAD_REQUEST),
+    QUEST_REWARD_ALREADY_CLAIMED("QUEST004", "이미 보상을 수령한 퀘스트입니다.", HttpStatus.BAD_REQUEST),
+    QUEST_ACCESS_DENIED("QUEST005", "해당 퀘스트에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    UNSUPPORTED_QUEST_TYPE("QUEST006", "지원하지 않는 퀘스트 타입입니다.", HttpStatus.BAD_REQUEST),
+
     // 스크랩 에러
     SCRAP_ALREADY_EXISTS("SCRAP001", "이미 스크랩한 뉴스입니다.", HttpStatus.CONFLICT),
     

--- a/main-server/src/main/java/com/freedom/common/exception/GlobalExceptionHandler.java
+++ b/main-server/src/main/java/com/freedom/common/exception/GlobalExceptionHandler.java
@@ -28,6 +28,36 @@ public class GlobalExceptionHandler {
 
     private final DiscordWebhookClient discordWebhookClient;
 
+    @ExceptionHandler(UserQuestNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleUserQuestNotFoundException(UserQuestNotFoundException e) {
+        return createErrorResponse(ErrorCode.USER_QUEST_NOT_FOUND);
+    }
+
+    @ExceptionHandler(UserWalletNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleUserWalletNotFoundException(UserWalletNotFoundException e) {
+        return createErrorResponse(ErrorCode.USER_WALLET_NOT_FOUND);
+    }
+
+    @ExceptionHandler(QuestAlreadyCompletedException.class)
+    public ResponseEntity<ErrorResponse> handleQuestAlreadyCompletedException(QuestAlreadyCompletedException e) {
+        return createErrorResponse(ErrorCode.QUEST_ALREADY_COMPLETED);
+    }
+
+    @ExceptionHandler(QuestRewardAlreadyClaimedException.class)
+    public ResponseEntity<ErrorResponse> handleQuestRewardAlreadyClaimedException(QuestRewardAlreadyClaimedException e) {
+        return createErrorResponse(ErrorCode.QUEST_REWARD_ALREADY_CLAIMED);
+    }
+
+    @ExceptionHandler(QuestAccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleQuestAccessDeniedException(QuestAccessDeniedException e) {
+        return createErrorResponse(ErrorCode.QUEST_ACCESS_DENIED);
+    }
+
+    @ExceptionHandler(UnsupportedQuestTypeException.class)
+    public ResponseEntity<ErrorResponse> handleUnsupportedQuestTypeException(UnsupportedQuestTypeException e) {
+        return createErrorResponse(ErrorCode.UNSUPPORTED_QUEST_TYPE);
+    }
+
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleUserNotFoundException(UserNotFoundException e) {
         log.warn("사용자를 찾을 수 없음: {}", e.getMessage());

--- a/main-server/src/main/java/com/freedom/common/exception/custom/QuestAccessDeniedException.java
+++ b/main-server/src/main/java/com/freedom/common/exception/custom/QuestAccessDeniedException.java
@@ -1,0 +1,16 @@
+package com.freedom.common.exception.custom;
+
+public class QuestAccessDeniedException extends RuntimeException {
+    
+    public QuestAccessDeniedException() {
+        super("해당 퀘스트에 접근할 권한이 없습니다.");
+    }
+    
+    public QuestAccessDeniedException(String message) {
+        super(message);
+    }
+    
+    public QuestAccessDeniedException(Long userQuestId) {
+        super("해당 퀘스트에 접근할 권한이 없습니다. userQuestId: " + userQuestId);
+    }
+}

--- a/main-server/src/main/java/com/freedom/common/exception/custom/QuestAlreadyCompletedException.java
+++ b/main-server/src/main/java/com/freedom/common/exception/custom/QuestAlreadyCompletedException.java
@@ -1,0 +1,16 @@
+package com.freedom.common.exception.custom;
+
+public class QuestAlreadyCompletedException extends RuntimeException {
+    
+    public QuestAlreadyCompletedException() {
+        super("이미 완료된 퀘스트입니다.");
+    }
+    
+    public QuestAlreadyCompletedException(String message) {
+        super(message);
+    }
+    
+    public QuestAlreadyCompletedException(Long userQuestId) {
+        super("이미 완료된 퀘스트입니다. userQuestId: " + userQuestId);
+    }
+}

--- a/main-server/src/main/java/com/freedom/common/exception/custom/QuestRewardAlreadyClaimedException.java
+++ b/main-server/src/main/java/com/freedom/common/exception/custom/QuestRewardAlreadyClaimedException.java
@@ -1,0 +1,16 @@
+package com.freedom.common.exception.custom;
+
+public class QuestRewardAlreadyClaimedException extends RuntimeException {
+    
+    public QuestRewardAlreadyClaimedException() {
+        super("이미 보상을 수령한 퀘스트입니다.");
+    }
+    
+    public QuestRewardAlreadyClaimedException(String message) {
+        super(message);
+    }
+    
+    public QuestRewardAlreadyClaimedException(Long userQuestId) {
+        super("이미 보상을 수령한 퀘스트입니다. userQuestId: " + userQuestId);
+    }
+}

--- a/main-server/src/main/java/com/freedom/common/exception/custom/UnsupportedQuestTypeException.java
+++ b/main-server/src/main/java/com/freedom/common/exception/custom/UnsupportedQuestTypeException.java
@@ -1,0 +1,8 @@
+package com.freedom.common.exception.custom;
+
+public class UnsupportedQuestTypeException extends RuntimeException {
+    
+    public UnsupportedQuestTypeException() {
+        super("지원하지 않는 퀘스트 타입입니다.");
+    }
+}

--- a/main-server/src/main/java/com/freedom/common/exception/custom/UserQuestNotFoundException.java
+++ b/main-server/src/main/java/com/freedom/common/exception/custom/UserQuestNotFoundException.java
@@ -1,0 +1,16 @@
+package com.freedom.common.exception.custom;
+
+public class UserQuestNotFoundException extends RuntimeException {
+    
+    public UserQuestNotFoundException() {
+        super("사용자 퀘스트를 찾을 수 없습니다.");
+    }
+    
+    public UserQuestNotFoundException(String message) {
+        super(message);
+    }
+    
+    public UserQuestNotFoundException(Long userQuestId) {
+        super("사용자 퀘스트를 찾을 수 없습니다. userQuestId: " + userQuestId);
+    }
+}

--- a/main-server/src/main/java/com/freedom/common/exception/custom/UserWalletNotFoundException.java
+++ b/main-server/src/main/java/com/freedom/common/exception/custom/UserWalletNotFoundException.java
@@ -1,0 +1,16 @@
+package com.freedom.common.exception.custom;
+
+public class UserWalletNotFoundException extends RuntimeException {
+    
+    public UserWalletNotFoundException() {
+        super("사용자 지갑을 찾을 수 없습니다.");
+    }
+    
+    public UserWalletNotFoundException(String message) {
+        super(message);
+    }
+    
+    public UserWalletNotFoundException(Long userId) {
+        super("사용자 지갑을 찾을 수 없습니다. userId: " + userId);
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/application/NewsQueryAppService.java
+++ b/main-server/src/main/java/com/freedom/news/application/NewsQueryAppService.java
@@ -5,6 +5,7 @@ import com.freedom.news.api.response.NewsResponse;
 import com.freedom.news.application.dto.NewsDetailDto;
 import com.freedom.news.application.dto.NewsDto;
 import com.freedom.news.domain.service.FindNewsService;
+import com.freedom.news.domain.service.NewsHistorySaveService;
 import com.freedom.scrap.application.dto.NewsScrapDto;
 import com.freedom.scrap.domain.service.FindNewsScrapService;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ public class NewsQueryAppService {
     
     private final FindNewsService findNewsService;
     private final FindNewsScrapService findNewsScrapService;
+    private final NewsHistorySaveService newsHistorySaveService;
 
     public Page<NewsResponse> getRecentNewsList(int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
@@ -30,6 +32,7 @@ public class NewsQueryAppService {
     public NewsDetailResponse getNewsDetail(Long newsId, Long userId) {
         NewsDetailDto newsDetailDto = findNewsService.findNewsById(newsId);
         NewsScrapDto newsScrapDto = findNewsScrapService.getNewsScrapById(newsId, userId);
+        newsHistorySaveService.saveNewsHistory(userId, newsId);
         return NewsDetailResponse.from(newsDetailDto, newsScrapDto);
     }
 }

--- a/main-server/src/main/java/com/freedom/news/domain/entity/NewsReadHistory.java
+++ b/main-server/src/main/java/com/freedom/news/domain/entity/NewsReadHistory.java
@@ -1,0 +1,40 @@
+package com.freedom.news.domain.entity;
+
+import com.freedom.common.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "news_read_history")
+public class NewsReadHistory extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "news_article_id", nullable = false)
+    private Long newsArticleId;
+
+    @Column(name = "read_at", nullable = false)
+    private LocalDateTime readAt;
+
+    @Builder
+    public NewsReadHistory(Long userId, Long newsArticleId, LocalDateTime readAt) {
+        this.userId = userId;
+        this.newsArticleId = newsArticleId;
+        this.readAt = readAt;
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/domain/service/FindNewsService.java
+++ b/main-server/src/main/java/com/freedom/news/domain/service/FindNewsService.java
@@ -5,6 +5,7 @@ import com.freedom.news.application.dto.NewsDetailDto;
 import com.freedom.news.application.dto.NewsDto;
 import com.freedom.news.domain.entity.NewsArticle;
 import com.freedom.news.infra.repository.NewsArticleRepository;
+import com.freedom.news.infra.repository.NewsHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,6 +20,7 @@ import java.time.LocalDateTime;
 public class FindNewsService {
     
     private final NewsArticleRepository newsArticleRepository;
+    private final NewsHistoryRepository newsHistoryRepository;
 
     @Transactional(readOnly = true)
     public Page<NewsDto> findRecentNews(Pageable pageable) {
@@ -53,5 +55,13 @@ public class FindNewsService {
     public NewsDetailDto findNewsById(Long newsId) {
         NewsArticle newsArticle = newsArticleRepository.findById(newsId).orElseThrow(() -> new NewsNotFoundException("존재하지 않는 뉴스 입니다." + newsId));
         return NewsDetailDto.from(newsArticle, newsArticle.getContentBlocks());
+    }
+
+    public int findNewsHistoryCountByUserId(Long userId) {
+        LocalDate today = LocalDate.now();
+        LocalDate thisWeekMonday = today.with(java.time.DayOfWeek.MONDAY);
+        LocalDateTime start = thisWeekMonday.atStartOfDay();
+        LocalDateTime end = LocalDateTime.now();
+        return newsHistoryRepository.countByUserIdAndReadAtBetween(userId, start, end);
     }
 }

--- a/main-server/src/main/java/com/freedom/news/domain/service/NewsHistorySaveService.java
+++ b/main-server/src/main/java/com/freedom/news/domain/service/NewsHistorySaveService.java
@@ -1,0 +1,27 @@
+package com.freedom.news.domain.service;
+
+import com.freedom.news.domain.entity.NewsReadHistory;
+import com.freedom.news.infra.repository.NewsHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class NewsHistorySaveService {
+
+    private final NewsHistoryRepository newsHistoryRepository;
+
+    public void saveNewsHistory(Long userId, Long newsId) {
+        NewsReadHistory history = newsHistoryRepository.findByUserIdAndNewsId(userId, newsId);
+        if(history == null) {
+            NewsReadHistory newHistory = NewsReadHistory.builder()
+                    .userId(userId)
+                    .newsArticleId(newsId)
+                    .readAt(LocalDateTime.now())
+                    .build();
+            newsHistoryRepository.save(newHistory);
+        }
+    }
+}

--- a/main-server/src/main/java/com/freedom/news/infra/repository/NewsHistoryRepository.java
+++ b/main-server/src/main/java/com/freedom/news/infra/repository/NewsHistoryRepository.java
@@ -1,0 +1,14 @@
+package com.freedom.news.infra.repository;
+
+import com.freedom.news.domain.entity.NewsReadHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface NewsHistoryRepository extends JpaRepository<NewsReadHistory, Long> {
+    NewsReadHistory findByUserIdAndNewsId(Long userId, Long newsId);
+
+    int countByUserIdAndReadAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
+}

--- a/main-server/src/main/java/com/freedom/quest/api/QuestController.java
+++ b/main-server/src/main/java/com/freedom/quest/api/QuestController.java
@@ -1,0 +1,35 @@
+package com.freedom.quest.api;
+
+import com.freedom.common.logging.Loggable;
+import com.freedom.common.security.CustomUserPrincipal;
+import com.freedom.quest.api.response.ClaimResponse;
+import com.freedom.quest.api.response.QuestSummaryResponse;
+import com.freedom.quest.application.QuestFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/quests")
+public class QuestController {
+
+    private final QuestFacade questFacade;
+
+    @Loggable("퀘스트 메인 조회")
+    @GetMapping("/current")
+    public ResponseEntity<List<QuestSummaryResponse>> getCurrentWeekQuests(@AuthenticationPrincipal CustomUserPrincipal principal) {
+        List<QuestSummaryResponse> response = questFacade.fetchAndUpdateCurrentWeek(principal.getId());
+        return ResponseEntity.ok(response);
+    }
+
+    @Loggable("퀘스트 보상 수령")
+    @PostMapping("/{userQuestId}/claim")
+    public ResponseEntity<ClaimResponse> claim(@AuthenticationPrincipal CustomUserPrincipal principal, @PathVariable Long userQuestId) {
+        ClaimResponse response = questFacade.questClaim(principal.getId(), userQuestId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/main-server/src/main/java/com/freedom/quest/api/response/ClaimResponse.java
+++ b/main-server/src/main/java/com/freedom/quest/api/response/ClaimResponse.java
@@ -1,0 +1,28 @@
+package com.freedom.quest.api.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ClaimResponse {
+    private boolean completed;
+    private Long userQuestId;
+    private String message;
+
+    public static ClaimResponse success(Long userQuestId) {
+        return ClaimResponse.builder()
+                .completed(true)
+                .userQuestId(userQuestId)
+                .message("퀘스트 보상이 성공적으로 지급되었습니다.")
+                .build();
+    }
+
+    public static ClaimResponse alreadyClaimed(Long userQuestId) {
+        return ClaimResponse.builder()
+                .completed(false)
+                .userQuestId(userQuestId)
+                .message("이미 보상을 받았습니다.")
+                .build();
+    }
+}

--- a/main-server/src/main/java/com/freedom/quest/api/response/QuestSummaryResponse.java
+++ b/main-server/src/main/java/com/freedom/quest/api/response/QuestSummaryResponse.java
@@ -1,0 +1,23 @@
+package com.freedom.quest.api.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class QuestSummaryResponse {
+    private Long userQuestId;
+    private String title;
+    private String description;
+    private LocalDate periodStart;
+    private LocalDate periodEnd;
+    private int requirementCount;
+    private int progressCount;
+    private int currentStreak;
+    private boolean completed;
+    private boolean claimed;
+    private BigDecimal rewardAmount;
+}

--- a/main-server/src/main/java/com/freedom/quest/application/QuestFacade.java
+++ b/main-server/src/main/java/com/freedom/quest/application/QuestFacade.java
@@ -1,0 +1,122 @@
+package com.freedom.quest.application;
+
+
+import com.freedom.attendance.domain.service.AttendanceReadService;
+import com.freedom.common.exception.custom.UnsupportedQuestTypeException;
+import com.freedom.news.domain.service.FindNewsService;
+import com.freedom.quest.api.response.ClaimResponse;
+import com.freedom.quest.api.response.QuestSummaryResponse;
+import com.freedom.quest.application.dto.UserQuestDto;
+import com.freedom.quest.domain.service.FindUserQuestService;
+import com.freedom.quest.domain.service.UserQuestCommandService;
+import com.freedom.quiz.domain.service.FindUserQuizService;
+import com.freedom.scrap.domain.service.FindScrapHistoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class QuestFacade {
+
+    private final FindUserQuestService findUserQuestService;
+    private final UserQuestCommandService userQuestCommandService;
+    private final AttendanceReadService attendanceReadService;
+    private final FindNewsService findNewsService;
+    private final FindUserQuizService findUserQuizService;
+    private final FindScrapHistoryService findScrapHistoryService;
+
+    public List<QuestSummaryResponse> fetchAndUpdateCurrentWeek(Long userId) {
+        List<UserQuestDto> userQuestList = findUserQuestService.findUserQuestById(userId);
+
+        if (userQuestList.isEmpty()) {
+            List<UserQuestDto> updateUserQuests = asyncUpdateUserQuests(userQuestCommandService.saveUserQuest(userId), userId);
+            return mapToQuestSummaryResponses(updateUserQuests);
+        }
+
+        List<UserQuestDto> updateUserQuests = asyncUpdateUserQuests(userQuestList, userId);
+        return mapToQuestSummaryResponses(updateUserQuests);
+    }
+
+    private List<UserQuestDto> asyncUpdateUserQuests(List<UserQuestDto> userQuests, Long userId) {
+        Map<Boolean, List<UserQuestDto>> partitioned = userQuests.stream()
+                .collect(Collectors.partitioningBy(UserQuestDto::isCompleted));
+
+        List<UserQuestDto> completedQuests = partitioned.get(true);
+        List<UserQuestDto> incompleteQuests = partitioned.get(false);
+
+        List<CompletableFuture<UserQuestDto>> futures = incompleteQuests.stream()
+                .map(uq -> CompletableFuture.supplyAsync(() -> updateSingleQuest(uq, userId)))
+                .toList();
+
+        List<UserQuestDto> updatedQuests = futures.stream()
+                .map(CompletableFuture::join)
+                .toList();
+
+        List<UserQuestDto> result = new ArrayList<>(completedQuests);
+        result.addAll(updatedQuests);
+        return result;
+    }
+
+    private UserQuestDto updateSingleQuest(UserQuestDto uq, Long userId) {
+        return switch(uq.getQuest().getTargetType()) {
+            case "ATTENDANCE" -> {
+                boolean attendanceCheck = attendanceReadService.wasAttendedYesterday(userId);
+                yield userQuestCommandService.updateAttendanceQuest(uq.getUserQuestId(), attendanceCheck, uq.getQuest().getRequirementCount());
+            }
+            case "NEWS" -> {
+                int newsHistoryCount = findNewsService.findNewsHistoryCountByUserId(userId);
+                yield userQuestCommandService.updateNewsQuest(uq.getUserQuestId(), newsHistoryCount, uq.getQuest().getRequirementCount());
+            }
+            case "QUIZ_CORRECT_ONLY" -> {
+                int quizHistoryCount = findUserQuizService.findQuizHistoryCountByUserId(userId);
+                yield userQuestCommandService.updateQuizQuest(uq.getUserQuestId(), quizHistoryCount, uq.getQuest().getRequirementCount());
+            }
+            case "SCRAP_NEWS" -> {
+                int newsScrapCount = findScrapHistoryService.findScrapHistoryCountByUserId(userId, "NEWS");
+                yield userQuestCommandService.updateScrapQuest(uq.getUserQuestId(), newsScrapCount, uq.getQuest().getRequirementCount());
+            }
+            case "SCRAP_QUIZ" -> {
+                int quizScrapCount = findScrapHistoryService.findScrapHistoryCountByUserId(userId, "QUIZ");
+                yield userQuestCommandService.updateScrapQuest(uq.getUserQuestId(), quizScrapCount, uq.getQuest().getRequirementCount());
+            }
+            /* case "FINANCE_PRODUCT" -> {
+                // TODO: 추후 추가 구현
+            }*/
+            default -> throw new UnsupportedQuestTypeException();
+        };
+    }
+
+
+    private List<QuestSummaryResponse> mapToQuestSummaryResponses(List<UserQuestDto> userQuests){
+        return userQuests.stream()
+                .map(uq -> QuestSummaryResponse.builder()
+                        .userQuestId(uq.getUserQuestId())
+                        .title(uq.getQuest().getTitle())
+                        .description(uq.getQuest().getDescription())
+                        .periodStart(uq.getPeriodStartDate())
+                        .periodEnd(uq.getPeriodEndDate())
+                        .requirementCount(uq.getQuest().getRequirementCount())
+                        .progressCount(uq.getProgressCount())
+                        .currentStreak(uq.getCurrentStreak())
+                        .completed(uq.isCompleted())
+                        .claimed(uq.isClaimed())
+                        .rewardAmount(uq.getQuest().getRewardAmount())
+                        .build()
+                ).toList();
+    }
+
+    public ClaimResponse questClaim(Long userId, Long userQuestId) {
+        if(findUserQuestService.checkQuestCompleted(userQuestId)){
+            userQuestCommandService.claimCompleted(userId, userQuestId);
+            return ClaimResponse.success(userQuestId);
+        } else{
+            return ClaimResponse.alreadyClaimed(userQuestId);
+        }
+    }
+}

--- a/main-server/src/main/java/com/freedom/quest/application/dto/QuestDto.java
+++ b/main-server/src/main/java/com/freedom/quest/application/dto/QuestDto.java
@@ -1,0 +1,20 @@
+package com.freedom.quest.application.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class QuestDto {
+    private Long questId;
+    private String title;
+    private String description;
+    private String periodType;
+    private String progressMode;
+    private String targetType;
+    private int requirementCount;
+    private BigDecimal rewardAmount;
+    private boolean active;
+}

--- a/main-server/src/main/java/com/freedom/quest/application/dto/UserQuestDto.java
+++ b/main-server/src/main/java/com/freedom/quest/application/dto/UserQuestDto.java
@@ -1,5 +1,6 @@
 package com.freedom.quest.application.dto;
 
+import com.freedom.quest.domain.entity.UserQuest;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,4 +15,29 @@ public class UserQuestDto {
     private LocalDate periodEndDate;
     private int progressCount;
     private int currentStreak;
+    private boolean completed;
+    private boolean claimed;
+
+    public static UserQuestDto toDto(UserQuest userQuest) {
+        return UserQuestDto.builder()
+                    .userQuestId(userQuest.getId())
+                    .quest(QuestDto.builder()
+                            .questId(userQuest.getQuest().getId())
+                            .title(userQuest.getQuest().getTitle())
+                            .description(userQuest.getQuest().getDescription())
+                            .periodType(userQuest.getQuest().getPeriodType().name())
+                            .progressMode(userQuest.getQuest().getProgressMode().name())
+                            .targetType(userQuest.getQuest().getTargetType().name())
+                            .requirementCount(userQuest.getQuest().getRequirementCount())
+                            .rewardAmount(userQuest.getQuest().getRewardAmount())
+                            .active(userQuest.getQuest().isActive())
+                            .build())
+                    .periodStartDate(userQuest.getPeriodStartDate())
+                    .periodEndDate(userQuest.getPeriodEndDate())
+                    .progressCount(userQuest.getProgressCount())
+                    .currentStreak(userQuest.getCurrentStreak())
+                    .completed(userQuest.isCompleted())
+                    .claimed(userQuest.isClaimed())
+                    .build();
+    }
 }

--- a/main-server/src/main/java/com/freedom/quest/application/dto/UserQuestDto.java
+++ b/main-server/src/main/java/com/freedom/quest/application/dto/UserQuestDto.java
@@ -1,0 +1,17 @@
+package com.freedom.quest.application.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class UserQuestDto {
+    private Long userQuestId;
+    private QuestDto quest;
+    private LocalDate periodStartDate;
+    private LocalDate periodEndDate;
+    private int progressCount;
+    private int currentStreak;
+}

--- a/main-server/src/main/java/com/freedom/quest/domain/entity/PeriodType.java
+++ b/main-server/src/main/java/com/freedom/quest/domain/entity/PeriodType.java
@@ -1,0 +1,7 @@
+package com.freedom.quest.domain.entity;
+
+public enum PeriodType {
+    WEEKLY,
+    DAILY,
+    SURPRISE
+}

--- a/main-server/src/main/java/com/freedom/quest/domain/entity/ProgressMode.java
+++ b/main-server/src/main/java/com/freedom/quest/domain/entity/ProgressMode.java
@@ -1,0 +1,6 @@
+package com.freedom.quest.domain.entity;
+
+public enum ProgressMode {
+    COUNT,   // 예: 뉴스 20개, 퀴즈 정답 25개, 스크랩 5개, 가입 1회
+    STREAK   // 예: 출석 5일 연속
+}

--- a/main-server/src/main/java/com/freedom/quest/domain/entity/Quest.java
+++ b/main-server/src/main/java/com/freedom/quest/domain/entity/Quest.java
@@ -1,0 +1,47 @@
+package com.freedom.quest.domain.entity;
+
+import com.freedom.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "quests")
+public class Quest extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 80)
+    private String title;
+
+    @Column(nullable = false, length = 300)
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "period_type", nullable = false, length = 20)
+    private PeriodType periodType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "progress_mode", nullable = false, length = 20)
+    private ProgressMode progressMode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false, length = 30)
+    private TargetType targetType;
+
+    @Column(nullable = false)
+    private int requirementCount;
+
+    @Column(nullable = false)
+    private BigDecimal rewardAmount;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active;
+}

--- a/main-server/src/main/java/com/freedom/quest/domain/entity/TargetType.java
+++ b/main-server/src/main/java/com/freedom/quest/domain/entity/TargetType.java
@@ -1,0 +1,10 @@
+package com.freedom.quest.domain.entity;
+
+public enum TargetType {
+    ATTENDANCE,        // 출석(yyyyMMdd 단위로 1일 1회 인정)
+    NEWS,              // 뉴스 상세 열람
+    QUIZ_CORRECT_ONLY, // 퀴즈 '정답'만 카운트 (중복 퀴즈 불가)
+    SCRAP_NEWS,        // 뉴스 스크랩 ON
+    SCRAP_QUIZ,        // 퀴즈 스크랩 ON
+    FINANCE_PRODUCT    // 금융상품 가입 (존재 여부 1회)
+}

--- a/main-server/src/main/java/com/freedom/quest/domain/entity/UserQuest.java
+++ b/main-server/src/main/java/com/freedom/quest/domain/entity/UserQuest.java
@@ -1,0 +1,84 @@
+package com.freedom.quest.domain.entity;
+
+import com.freedom.auth.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Entity
+@Table(
+        name = "user_quests",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_user_quest_period",
+                        columnNames = {"user_id", "quest_id", "period_start_date"})
+        }
+)
+public class UserQuest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "quest_id", nullable = false)
+    private Quest quest;
+
+    @Column(name = "period_start_date", nullable = false)
+    private LocalDate periodStartDate;
+
+    @Column(name = "period_end_date", nullable = false)
+    private LocalDate periodEndDate;
+
+    @Column(nullable = false)
+    private int progressCount;
+
+    @Column(nullable = false)
+    private int currentStreak;
+
+    @Column(name = "is_claimed", nullable = false)
+    private boolean isClaimed;
+
+    @Column(name = "is_completed", nullable = false)
+    private boolean completed;
+
+    @Builder
+    public UserQuest(User user, Quest quest, LocalDate periodStartDate, LocalDate periodEndDate, int progressCount, int currentStreak) {
+        this.user = user;
+        this.quest = quest;
+        this.periodStartDate = periodStartDate;
+        this.periodEndDate = periodEndDate;
+        this.progressCount = progressCount;
+        this.currentStreak = currentStreak;
+        this.isClaimed = false;
+        this.completed = false;
+    }
+
+    public void currentStreakPlusOne(){
+        this.currentStreak += 1;
+    }
+
+    public void currentStreakZero(){
+        this.currentStreak = 0;
+    }
+
+    public void completeQuest() {
+        this.completed = true;
+    }
+
+    public void claimReward() {
+        this.isClaimed = true;
+    }
+
+    public void updateProgressCount(int checkCount,int count) {
+        this.progressCount = Math.min(checkCount, count);
+    }
+}

--- a/main-server/src/main/java/com/freedom/quest/domain/service/FindUserQuestService.java
+++ b/main-server/src/main/java/com/freedom/quest/domain/service/FindUserQuestService.java
@@ -1,0 +1,42 @@
+package com.freedom.quest.domain.service;
+
+import com.freedom.quest.application.dto.QuestDto;
+import com.freedom.quest.application.dto.UserQuestDto;
+import com.freedom.quest.domain.entity.UserQuest;
+import com.freedom.quest.infra.repository.UserQuestJPARepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FindUserQuestService {
+
+    private final UserQuestJPARepository userQuestRepository;
+
+    @Transactional(readOnly = true)
+    public List<UserQuestDto> findUserQuestById(Long id) {
+        LocalDate now = LocalDate.now();
+        LocalDate startOfWeek = now.with(DayOfWeek.MONDAY);
+        LocalDate endOfWeek = now.with(DayOfWeek.SUNDAY);
+
+        List<UserQuest> userQuestList = userQuestRepository.findByUserIdAndPeriodOverlap(id, startOfWeek, endOfWeek);
+        if (userQuestList.isEmpty()) {
+            return List.of();
+        }
+        return userQuestList.stream()
+                .map(UserQuestDto::toDto)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public boolean checkQuestCompleted(Long userQuestId) {
+        return userQuestRepository.findById(userQuestId)
+                .map(uq -> uq.isCompleted() && !uq.isClaimed())
+                .orElse(false);
+    }
+}

--- a/main-server/src/main/java/com/freedom/quest/domain/service/UserQuestCommandService.java
+++ b/main-server/src/main/java/com/freedom/quest/domain/service/UserQuestCommandService.java
@@ -1,0 +1,142 @@
+package com.freedom.quest.domain.service;
+
+import com.freedom.auth.domain.User;
+import com.freedom.auth.infra.UserJpaRepository;
+import com.freedom.common.exception.custom.*;
+import com.freedom.quest.application.dto.UserQuestDto;
+import com.freedom.quest.domain.entity.Quest;
+import com.freedom.quest.domain.entity.TargetType;
+import com.freedom.quest.domain.entity.UserQuest;
+import com.freedom.quest.infra.repository.QuestJPARepository;
+import com.freedom.quest.infra.repository.UserQuestJPARepository;
+import com.freedom.wallet.domain.UserWallet;
+import com.freedom.wallet.domain.UserWalletRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.IsoFields;
+import java.util.List;
+import java.util.function.Consumer;
+
+@Service
+@RequiredArgsConstructor
+public class UserQuestCommandService {
+
+    private final UserQuestJPARepository userQuestRepository;
+    private final QuestJPARepository questRepository;
+    private final UserJpaRepository userRepository;
+    private final UserWalletRepository userWalletRepository;
+
+    @Transactional
+    public List<UserQuestDto> saveUserQuest(long userId) {
+        LocalDate now = LocalDate.now();
+        LocalDate startOfWeek = now.with(DayOfWeek.MONDAY);
+        LocalDate endOfWeek = now.with(DayOfWeek.SUNDAY);
+
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
+
+        List<Quest> questList = questRepository.findAllByIsActiveTrue();
+        List<UserQuest> userQuestList = questList.stream()
+                .filter(quest -> {
+                    if (quest.getTargetType() != TargetType.SCRAP_NEWS && quest.getTargetType() != TargetType.SCRAP_QUIZ) {
+                        return true;
+                    }
+                    int week = now.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+                    if (week % 2 == 1) {
+                        return quest.getTargetType() == TargetType.SCRAP_NEWS;
+                    } else {
+                        return quest.getTargetType() == TargetType.SCRAP_QUIZ;
+                    }
+                })
+                .map(quest -> UserQuest.builder()
+                        .user(user)
+                        .quest(quest)
+                        .periodStartDate(startOfWeek)
+                        .periodEndDate(endOfWeek)
+                        .progressCount(0)
+                        .currentStreak(0)
+                        .build()
+                ).toList();
+        List<UserQuest> savedUserQuestList = userQuestRepository.saveAll(userQuestList);
+
+        return savedUserQuestList.stream()
+                .map(UserQuestDto::toDto)
+                .toList();
+    }
+
+    @Transactional
+    public UserQuestDto updateAttendanceQuest(Long userQuestId, boolean attendanceCheck, int requirementCount) {
+        if(!attendanceCheck) {
+            return updateQuestProgress(
+                    userQuestId,
+                    requirementCount,
+                    UserQuest::currentStreakZero
+            );
+        }
+        return updateQuestProgress(
+                userQuestId,
+                requirementCount,
+                UserQuest::currentStreakPlusOne
+        );
+    }
+
+    @Transactional
+    public UserQuestDto updateNewsQuest(Long userQuestId, int newsHistoryCount, int requirementCount) {
+        return updateQuestProgress(
+                userQuestId,
+                requirementCount,
+                (userQuest) -> userQuest.updateProgressCount(requirementCount, newsHistoryCount)
+        );
+    }
+
+    @Transactional
+    public UserQuestDto updateQuizQuest(Long userQuestId, int quizHistoryCount, int requirementCount) {
+        return updateQuestProgress(
+                userQuestId,
+                requirementCount,
+                (userQuest) -> userQuest.updateProgressCount(requirementCount, quizHistoryCount)
+        );
+    }
+
+    @Transactional
+    public UserQuestDto updateScrapQuest(Long userQuestId, int newsScrapCount, int requirementCount) {
+        return updateQuestProgress(
+                userQuestId,
+                requirementCount,
+                (userQuest) -> userQuest.updateProgressCount(requirementCount, newsScrapCount)
+        );
+    }
+
+    private UserQuestDto updateQuestProgress(Long userQuestId, int requirementCount, Consumer<UserQuest> updater) {
+        UserQuest userQuest = userQuestRepository.findById(userQuestId)
+                .orElseThrow(() -> new UserQuestNotFoundException(userQuestId));
+        updater.accept(userQuest);
+
+        if ((userQuest.getProgressCount() >= requirementCount) || (userQuest.getCurrentStreak() == requirementCount)) {
+            userQuest.completeQuest();
+        }
+        UserQuest updatedUserQuest = userQuestRepository.save(userQuest);
+        return UserQuestDto.toDto(updatedUserQuest);
+    }
+
+    @Transactional
+    public void claimCompleted(Long userId, Long userQuestId) {
+        UserWallet wallet = userWalletRepository.findByUserIdForUpdate(userId).orElseThrow(() -> new UserWalletNotFoundException(userId));
+        UserQuest userQuest = userQuestRepository.findById(userQuestId)
+                .orElseThrow(() -> new UserQuestNotFoundException(userQuestId));
+
+        User user = userQuest.getUser();
+        if (!user.getId().equals(userId)) {
+            throw new QuestAccessDeniedException(userQuestId);
+        }
+
+        wallet.deposit(userQuest.getQuest().getRewardAmount());
+        userWalletRepository.save(wallet);
+
+        userQuest.claimReward();
+        userQuestRepository.save(userQuest);
+    }
+}

--- a/main-server/src/main/java/com/freedom/quest/infra/repository/QuestJPARepository.java
+++ b/main-server/src/main/java/com/freedom/quest/infra/repository/QuestJPARepository.java
@@ -1,0 +1,12 @@
+package com.freedom.quest.infra.repository;
+
+import com.freedom.quest.domain.entity.Quest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface QuestJPARepository extends JpaRepository<Quest, Long> {
+    List<Quest> findAllByIsActiveTrue();
+}

--- a/main-server/src/main/java/com/freedom/quest/infra/repository/UserQuestJPARepository.java
+++ b/main-server/src/main/java/com/freedom/quest/infra/repository/UserQuestJPARepository.java
@@ -1,0 +1,21 @@
+package com.freedom.quest.infra.repository;
+
+import com.freedom.quest.domain.entity.UserQuest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface UserQuestJPARepository extends JpaRepository<UserQuest, Long> {
+
+    @Query("SELECT uq FROM UserQuest uq WHERE uq.user.id = :userId " +
+           "AND uq.periodStartDate <= :endDate AND uq.periodEndDate >= :startDate")
+    List<UserQuest> findByUserIdAndPeriodOverlap(@Param("userId") Long userId, 
+                                                  @Param("startDate") LocalDate startDate, 
+                                                  @Param("endDate") LocalDate endDate);
+
+}

--- a/main-server/src/main/java/com/freedom/quiz/application/QuizFacade.java
+++ b/main-server/src/main/java/com/freedom/quiz/application/QuizFacade.java
@@ -20,6 +20,7 @@ public class QuizFacade {
     private final FindUserQuizService findUserQuizService;
     private final CreateDailyQuizService createDailyQuizService;
     private final UpdateUserQuizService updateUserQuizService;
+    private final QuizHistorySaveService quizHistorySaveService;
 
     @Transactional
     public DailyQuizDto getDailyQuizzes(Long userId) {
@@ -53,7 +54,15 @@ public class QuizFacade {
                 : userQuizDto.getMcqCorrectIndex() != null &&
                   userQuizDto.getMcqCorrectIndex().toString().equals(userAnswer);
 
+        quizHistorySave(userQuizDto, isCorrect);
+
         updateUserQuizService.updateAnswer(userQuizId, userAnswer, isCorrect);
         return QuizAnswerResultResponse.from(isCorrect, userQuizDto);
+    }
+
+    private void quizHistorySave(UserQuizDto userQuizDto, boolean isCorrect) {
+        if(userQuizDto.getUserAnswer() == null && isCorrect) { // 최초 시도 정답 제출 시에만 히스토리 저장
+            quizHistorySaveService.quizHistorySave(userQuizDto.getUserId(), userQuizDto.getQuizId());
+        }
     }
 }

--- a/main-server/src/main/java/com/freedom/quiz/application/dto/UserQuizDto.java
+++ b/main-server/src/main/java/com/freedom/quiz/application/dto/UserQuizDto.java
@@ -12,6 +12,7 @@ import java.time.LocalDate;
 @Builder
 public class UserQuizDto {
     private final Long userQuizId;
+    private final Long userId;
     private final Long quizId;
     private final QuizType type;
     private final String category;  // 퀴즈 카테고리 (news, quiz)
@@ -41,6 +42,7 @@ public class UserQuizDto {
     public static UserQuizDto from(UserQuiz userQuiz, Quiz quiz, String newsUrl) {
         return UserQuizDto.builder()
                 .userQuizId(userQuiz.getId())
+                .userId(userQuiz.getUserId())
                 .quizId(quiz.getId())
                 .type(quiz.getType())
                 .category(quiz.getCategory())

--- a/main-server/src/main/java/com/freedom/quiz/domain/entity/QuizHistory.java
+++ b/main-server/src/main/java/com/freedom/quiz/domain/entity/QuizHistory.java
@@ -1,0 +1,37 @@
+package com.freedom.quiz.domain.entity;
+
+import com.freedom.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "quiz_history")
+public class QuizHistory extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name= "quiz_id", nullable = false)
+    private Long quizId;
+
+    @Column(name = "answered_at", nullable = false)
+    private LocalDateTime answeredAt;
+
+    @Builder
+    public QuizHistory(Long userId, Long quizId, LocalDateTime answeredAt) {
+        this.userId = userId;
+        this.quizId = quizId;
+        this.answeredAt = answeredAt;
+    }
+}

--- a/main-server/src/main/java/com/freedom/quiz/domain/service/FindUserQuizService.java
+++ b/main-server/src/main/java/com/freedom/quiz/domain/service/FindUserQuizService.java
@@ -3,11 +3,13 @@ package com.freedom.quiz.domain.service;
 import com.freedom.common.exception.custom.UserQuizNotFoundException;
 import com.freedom.quiz.application.dto.UserQuizDto;
 import com.freedom.quiz.domain.entity.UserQuiz;
+import com.freedom.quiz.infra.QuizHistoryRepository;
 import com.freedom.quiz.infra.UserQuizRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -15,6 +17,7 @@ import java.util.List;
 public class FindUserQuizService {
 
     private final UserQuizRepository userQuizRepository;
+    private final QuizHistoryRepository quizHistoryRepository;
 
     public List<UserQuizDto> findDailyQuizzes(Long userId, LocalDate quizDate) {
         List<UserQuiz> userQuizzes = userQuizRepository.findByUserIdAndQuizDate(userId, quizDate);
@@ -36,5 +39,13 @@ public class FindUserQuizService {
             throw new UserQuizNotFoundException(String.valueOf(userQuizId));
         }
         return quizId;
+    }
+
+    public int findQuizHistoryCountByUserId(Long userId) {
+        LocalDate today = LocalDate.now();
+        LocalDate thisWeekMonday = today.with(java.time.DayOfWeek.MONDAY);
+        LocalDateTime start = thisWeekMonday.atStartOfDay();
+        LocalDateTime end = LocalDateTime.now();
+        return quizHistoryRepository.countByUserIdAndAnsweredAtBetween(userId, start, end);
     }
 }

--- a/main-server/src/main/java/com/freedom/quiz/domain/service/QuizHistorySaveService.java
+++ b/main-server/src/main/java/com/freedom/quiz/domain/service/QuizHistorySaveService.java
@@ -1,0 +1,27 @@
+package com.freedom.quiz.domain.service;
+
+import com.freedom.quiz.domain.entity.QuizHistory;
+import com.freedom.quiz.infra.QuizHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class QuizHistorySaveService {
+
+    private final QuizHistoryRepository quizHistoryRepository;
+
+    public void quizHistorySave(Long userId, Long quizId) {
+        QuizHistory history = quizHistoryRepository.findByUserIdAndQuizId(userId, quizId);
+        if(history == null) {
+            QuizHistory quizHistory = QuizHistory.builder()
+                    .userId(userId)
+                    .quizId(quizId)
+                    .answeredAt(LocalDateTime.now())
+                    .build();
+            quizHistoryRepository.save(quizHistory);
+        }
+    }
+}

--- a/main-server/src/main/java/com/freedom/quiz/infra/QuizHistoryRepository.java
+++ b/main-server/src/main/java/com/freedom/quiz/infra/QuizHistoryRepository.java
@@ -1,0 +1,15 @@
+package com.freedom.quiz.infra;
+
+import com.freedom.quiz.domain.entity.QuizHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface QuizHistoryRepository extends JpaRepository<QuizHistory, Long> {
+
+    QuizHistory findByUserIdAndQuizId(Long userId, Long quizId);
+
+    int countByUserIdAndAnsweredAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
+}

--- a/main-server/src/main/java/com/freedom/scrap/domain/entity/ScrapHistory.java
+++ b/main-server/src/main/java/com/freedom/scrap/domain/entity/ScrapHistory.java
@@ -1,0 +1,44 @@
+package com.freedom.scrap.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Entity
+@Table(name = "scrap_history")
+public class ScrapHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "scrap_id", nullable = false)
+    private Long scrapId;
+
+    @Enumerated(EnumType.STRING)
+    private ScrapType type;
+
+    private LocalDateTime scrapAt;
+
+    public enum ScrapType {
+        NEWS, QUIZ
+    }
+
+    @Builder
+    public ScrapHistory(Long userId, Long scrapId, ScrapType type, LocalDateTime scrapAt) {
+        this.userId = userId;
+        this.scrapId = scrapId;
+        this.type = type;
+        this.scrapAt = scrapAt != null ? scrapAt : LocalDateTime.now();
+    }
+}

--- a/main-server/src/main/java/com/freedom/scrap/domain/service/FindScrapHistoryService.java
+++ b/main-server/src/main/java/com/freedom/scrap/domain/service/FindScrapHistoryService.java
@@ -1,0 +1,28 @@
+package com.freedom.scrap.domain.service;
+
+import com.freedom.scrap.domain.entity.ScrapHistory;
+import com.freedom.scrap.infra.ScrapHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class FindScrapHistoryService {
+
+    private final ScrapHistoryRepository scrapHistoryRepository;
+
+    public int findScrapHistoryCountByUserId(Long userId, String category) {
+        LocalDate today = LocalDate.now();
+        LocalDate thisWeekMonday = today.with(java.time.DayOfWeek.MONDAY);
+        LocalDateTime start = thisWeekMonday.atStartOfDay();
+        LocalDateTime end = LocalDateTime.now();
+        if(category.equals("NEWS")) {
+            return scrapHistoryRepository.countByUserIdAndTypeAndScrapAtBetween(userId, ScrapHistory.ScrapType.NEWS, start, end);
+        }else{
+            return scrapHistoryRepository.countByUserIdAndTypeAndScrapAtBetween(userId, ScrapHistory.ScrapType.QUIZ, start, end);
+        }
+    }
+}

--- a/main-server/src/main/java/com/freedom/scrap/domain/service/NewsScrapToggleService.java
+++ b/main-server/src/main/java/com/freedom/scrap/domain/service/NewsScrapToggleService.java
@@ -3,16 +3,22 @@ package com.freedom.scrap.domain.service;
 import com.freedom.auth.domain.User;
 import com.freedom.news.domain.entity.NewsArticle;
 import com.freedom.scrap.domain.entity.NewsScrap;
+import com.freedom.scrap.domain.entity.ScrapHistory;
 import com.freedom.scrap.infra.NewsScrapRepository;
+import com.freedom.scrap.infra.ScrapHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class NewsScrapToggleService {
     
     private final NewsScrapRepository newsScrapRepository;
-    
+    private final ScrapHistoryRepository scrapHistoryRepository;
+
     public boolean toggleNewsScrap(User user, Long newsId) {
         return newsScrapRepository.findByUserIdAndNewsArticleId(user.getId(), newsId)
                 .map(existingScrap -> {
@@ -22,6 +28,11 @@ public class NewsScrapToggleService {
                 .orElseGet(() -> {
                     NewsScrap newsScrap = NewsScrap.create(user, NewsArticle.createNewsArticle(newsId));
                     newsScrapRepository.save(newsScrap);
+                    ScrapHistory history = scrapHistoryRepository.findByUserIdAndScrapIdAndType(user.getId(), newsId, ScrapHistory.ScrapType.NEWS);
+                    if (history == null) {
+                        ScrapHistory scrapHistory = ScrapHistory.builder().userId(user.getId()).scrapId(newsId).type(ScrapHistory.ScrapType.NEWS).scrapAt(LocalDateTime.now()).build();
+                        scrapHistoryRepository.save(scrapHistory);
+                    }
                     return true;
                 });
     }

--- a/main-server/src/main/java/com/freedom/scrap/domain/service/QuizScrapToggleService.java
+++ b/main-server/src/main/java/com/freedom/scrap/domain/service/QuizScrapToggleService.java
@@ -4,16 +4,21 @@ import com.freedom.auth.domain.User;
 import com.freedom.common.logging.Loggable;
 import com.freedom.quiz.domain.entity.UserQuiz;
 import com.freedom.scrap.domain.entity.QuizScrap;
+import com.freedom.scrap.domain.entity.ScrapHistory;
 import com.freedom.scrap.infra.QuizScrapRepository;
+import com.freedom.scrap.infra.ScrapHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class QuizScrapToggleService {
     
     private final QuizScrapRepository quizScrapRepository;
-    
+    private final ScrapHistoryRepository scrapHistoryRepository;
+
     @Loggable("퀴즈 스크랩 토글")
     public boolean toggleQuizScrap(User user, Long userQuizId, Boolean isCorrectAtScrap) {
         return quizScrapRepository.findByUserIdAndUserQuizId(user.getId(), userQuizId)
@@ -24,6 +29,11 @@ public class QuizScrapToggleService {
                 .orElseGet(() -> {
                     QuizScrap quizScrap = QuizScrap.create(user, UserQuiz.createUserQuiz(userQuizId), isCorrectAtScrap);
                     quizScrapRepository.save(quizScrap);
+                    ScrapHistory history = scrapHistoryRepository.findByUserIdAndScrapIdAndType(user.getId(), userQuizId, ScrapHistory.ScrapType.QUIZ);
+                    if (history == null) {
+                        ScrapHistory scrapHistory = ScrapHistory.builder().userId(user.getId()).scrapId(userQuizId).type(ScrapHistory.ScrapType.QUIZ).scrapAt(LocalDateTime.now()).build();
+                        scrapHistoryRepository.save(scrapHistory);
+                    }
                     return true; // 등록됨
                 });
     }

--- a/main-server/src/main/java/com/freedom/scrap/infra/ScrapHistoryRepository.java
+++ b/main-server/src/main/java/com/freedom/scrap/infra/ScrapHistoryRepository.java
@@ -1,0 +1,15 @@
+package com.freedom.scrap.infra;
+
+import com.freedom.scrap.domain.entity.ScrapHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface ScrapHistoryRepository extends JpaRepository<ScrapHistory, Long> {
+
+    ScrapHistory findByUserIdAndScrapIdAndType(Long userId, Long scrapId, ScrapHistory.ScrapType scrapType);
+
+    int countByUserIdAndTypeAndScrapAtBetween(Long userId, ScrapHistory.ScrapType scrapType, LocalDateTime start, LocalDateTime end);
+}

--- a/main-server/src/main/java/com/freedom/wallet/domain/UserWalletRepository.java
+++ b/main-server/src/main/java/com/freedom/wallet/domain/UserWalletRepository.java
@@ -1,5 +1,10 @@
 package com.freedom.wallet.domain;
 
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.Optional;
 
 /**
@@ -32,4 +37,6 @@ public interface UserWalletRepository {
      * 지갑 삭제
      */
     void delete(UserWallet wallet);
+
+    Optional<UserWallet> findByUserIdForUpdate(Long userId);
 }

--- a/main-server/src/main/java/com/freedom/wallet/infra/UserWalletJpaAdapter.java
+++ b/main-server/src/main/java/com/freedom/wallet/infra/UserWalletJpaAdapter.java
@@ -40,4 +40,9 @@ public class UserWalletJpaAdapter implements UserWalletRepository {
     public void delete(UserWallet wallet) {
         jpaRepository.delete(wallet);
     }
+
+    @Override
+    public Optional<UserWallet> findByUserIdForUpdate(Long userId) {
+        return jpaRepository.findByUserIdForUpdate(userId);
+    }
 }

--- a/main-server/src/main/java/com/freedom/wallet/infra/UserWalletJpaRepository.java
+++ b/main-server/src/main/java/com/freedom/wallet/infra/UserWalletJpaRepository.java
@@ -1,7 +1,10 @@
 package com.freedom.wallet.infra;
 
 import com.freedom.wallet.domain.UserWallet;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -21,4 +24,8 @@ public interface UserWalletJpaRepository extends JpaRepository<UserWallet, Long>
      * 사용자 ID로 지갑 존재 여부 확인
      */
     boolean existsByUserId(Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from UserWallet u where u.userId = :userId")
+    Optional<UserWallet> findByUserIdForUpdate(Long userId);
 }


### PR DESCRIPTION
## API 엔드포인트부터 비즈니스 로직 오케스트레이션
``` mermaid
sequenceDiagram
    participant Client as 클라이언트
    participant QC as QuestController
    participant QF as QuestFacade
    participant FUQS as FindUserQuestService
    participant UQCS as UserQuestCommandService

    Note over Client, UQCS: API 엔드포인트부터 비즈니스 로직 오케스트레이션

    Client->>+QC: GET /api/quests/current
    Note over QC: @AuthenticationPrincipal CustomUserPrincipal principal<br/>사용자 인증 정보 자동 주입

    QC->>+QF: fetchAndUpdateCurrentWeek(principal.getId())
    Note over QF: 현재 주차 퀘스트 조회 및 진행도 업데이트 오케스트레이션

    QF->>+FUQS: findUserQuestById(userId)
    Note over FUQS: 현재 주차에 해당하는 사용자 퀘스트 조회

    alt 기존 퀘스트가 없는 경우 (신규 사용자 또는 새로운 주차)
        FUQS-->>QF: List.of() (빈 리스트)
        
        QF->>+UQCS: saveUserQuest(userId)
        Note over UQCS: 새로운 주간 퀘스트 생성 로직 실행
        UQCS-->>-QF: List<UserQuestDto> (생성된 퀘스트들)
        
        QF->>QF: asyncUpdateUserQuests(newUserQuests, userId)
        Note over QF: 생성된 퀘스트들의 진행도 비동기 업데이트

    else 기존 퀘스트가 있는 경우
        FUQS-->>-QF: List<UserQuestDto> (기존 퀘스트들)
        
        QF->>QF: asyncUpdateUserQuests(existingUserQuests, userId)
        Note over QF: 기존 퀘스트들의 진행도 비동기 업데이트
    end

    QF->>QF: mapToQuestSummaryResponses(updatedUserQuests)
    Note over QF: UserQuestDto -> QuestSummaryResponse 매핑

    loop 각 UserQuestDto 변환
        QF->>QF: QuestSummaryResponse.builder()<br/>.userQuestId(uq.getUserQuestId())<br/>.title(uq.getQuest().getTitle())<br/>.description(uq.getQuest().getDescription())<br/>.periodStart(uq.getPeriodStartDate())<br/>.periodEnd(uq.getPeriodEndDate())<br/>.requirementCount(uq.getQuest().getRequirementCount())<br/>.progressCount(uq.getProgressCount())<br/>.currentStreak(uq.getCurrentStreak())<br/>.completed(uq.isCompleted())<br/>.claimed(uq.isClaimed())<br/>.rewardAmount(uq.getQuest().getRewardAmount())<br/>.build()
    end

    QF-->>-QC: List<QuestSummaryResponse>
    QC-->>-Client: ResponseEntity.ok(response)

    Note over Client: 응답 예시:<br/>{<br/> "userQuestId": 1,<br/> "title": "주간 출석 챌린지",<br/> "description": "5일간 연속으로 출석하시 보상 30만원 제공",<br/> "periodStart": "2025-09-16",<br/> "periodEnd": "2025-09-22",<br/> "requirementCount": 5,<br/> "progressCount": 0,<br/> "currentStreak": 3,<br/> "completed": false,<br/> "claimed": false,<br/> "rewardAmount": 300000<br/>}
```
## CompletableFuture 기반 병렬 처리 로직
``` mermaid
sequenceDiagram
    participant QF as QuestFacade
    participant Stream as Java Stream
    participant CF as CompletableFuture
    participant UpdateLogic as updateSingleQuest

    Note over QF, UpdateLogic: CompletableFuture 기반 병렬 처리 로직

    QF->>QF: asyncUpdateUserQuests(userQuests, userId)
    
    QF->>+Stream: userQuests.stream().collect(Collectors.partitioningBy(UserQuestDto::isCompleted))
    Stream-->>-QF: Map<Boolean, List<UserQuestDto>> partitioned

    QF->>QF: completedQuests = partitioned.get(true)<br/>incompleteQuests = partitioned.get(false)
    Note over QF: 완료된 퀘스트와 미완료 퀘스트 분리

    QF->>+Stream: incompleteQuests.stream()
    
    loop 각 미완료 퀘스트별
        Stream->>+CF: CompletableFuture.supplyAsync(() -> updateSingleQuest(uq, userId))
        Note over CF: 별도 스레드에서 비동기 실행
        
        CF->>+UpdateLogic: updateSingleQuest(uq, userId)
        
        UpdateLogic->>UpdateLogic: switch(uq.getQuest().getTargetType())
        
        alt ATTENDANCE 퀘스트
            UpdateLogic->>UpdateLogic: attendanceReadService.wasAttendedYesterday(userId)<br/>userQuestCommandService.updateAttendanceQuest(...)
            
        else NEWS 퀘스트
            UpdateLogic->>UpdateLogic: findNewsService.findNewsHistoryCountByUserId(userId)<br/>userQuestCommandService.updateNewsQuest(...)
            
        else QUIZ_CORRECT_ONLY 퀘스트
            UpdateLogic->>UpdateLogic: findUserQuizService.findQuizHistoryCountByUserId(userId)<br/>userQuestCommandService.updateQuizQuest(...)
            
        else SCRAP_NEWS 퀘스트
            UpdateLogic->>UpdateLogic: findScrapHistoryService.findScrapHistoryCountByUserId(userId, "NEWS")<br/>userQuestCommandService.updateScrapQuest(...)
            
        else SCRAP_QUIZ 퀘스트
            UpdateLogic->>UpdateLogic: findScrapHistoryService.findScrapHistoryCountByUserId(userId, "QUIZ")<br/>userQuestCommandService.updateScrapQuest(...)
            
        else 지원하지 않는 타입
            UpdateLogic->>UpdateLogic: throw new UnsupportedQuestTypeException()
        end
        
        UpdateLogic-->>-CF: UserQuestDto (업데이트된 퀘스트)
        CF-->>-Stream: CompletableFuture<UserQuestDto>
    end
    
    Stream-->>-QF: List<CompletableFuture<UserQuestDto>> futures

    QF->>+Stream: futures.stream().map(CompletableFuture::join).toList()
    Note over Stream: 모든 비동기 작업 완료 대기 (blocking)
    
    loop 각 CompletableFuture 완료 대기
        Stream->>CF: CompletableFuture.join()
        CF-->>Stream: UserQuestDto (완료된 결과)
    end
    
    Stream-->>-QF: List<UserQuestDto> updatedQuests

    QF->>QF: result = new ArrayList<>(completedQuests)<br/>result.addAll(updatedQuests)
    Note over QF: 완료된 퀘스트 + 업데이트된 퀘스트 병합

    QF->>QF: return result
    Note over QF: 최종 업데이트된 전체 퀘스트 리스트 반환

    Note over QF: 성능 최적화 포인트:<br/>• 완료된 퀘스트는 업데이트 스킵<br/>• 미완료 퀘스트만 병렬 처리<br/>• 각 퀘스트별 독립적 스레드 실행
```
## 퀘스트 상태 업데이트 및 완료 조건 체크
``` mermaid
sequenceDiagram
    participant UQCS as UserQuestCommandService
    participant UQRepo as UserQuestJPARepository
    participant QRepo as QuestJPARepository
    participant URepo as UserJpaRepository
    participant UserQuest as UserQuest Entity

    Note over UQCS, UserQuest: 퀘스트 상태 업데이트 및 완료 조건 체크

    Note over UQCS, URepo: 새로운 퀘스트 생성 (saveUserQuest)
    UQCS->>UQCS: saveUserQuest(userId)
    Note over UQCS: @Transactional 트랜잭션 시작

    UQCS->>UQCS: LocalDate now = LocalDate.now()<br/>LocalDate startOfWeek = now.with(DayOfWeek.MONDAY)<br/>LocalDate endOfWeek = now.with(DayOfWeek.SUNDAY)

    UQCS->>+URepo: findById(userId)
    URepo-->>-UQCS: User user

    UQCS->>+QRepo: findAllByIsActiveTrue()
    QRepo-->>-UQCS: List<Quest> questList

    UQCS->>UQCS: 격주 스크랩 퀘스트 필터링
    Note over UQCS: if (quest.getTargetType() != SCRAP_NEWS && quest.getTargetType() != SCRAP_QUIZ)<br/>    return true<br/>int week = now.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR)<br/>if (week % 2 == 1) return SCRAP_NEWS<br/>else return SCRAP_QUIZ

    loop 필터링된 각 퀘스트
        UQCS->>UQCS: UserQuest.builder()<br/>.user(user).quest(quest)<br/>.periodStartDate(startOfWeek).periodEndDate(endOfWeek)<br/>.progressCount(0).currentStreak(0).build()
    end

    UQCS->>+UQRepo: saveAll(userQuestList)
    UQRepo-->>-UQCS: List<UserQuest> savedUserQuestList

    UQCS->>UQCS: UserQuestDto.toDto() 변환
    UQCS->>UQCS: return List<UserQuestDto>

    Note over UQCS, UserQuest: 퀘스트 진행도 업데이트 (updateQuestProgress)
        
    alt updateAttendanceQuest 호출
        UQCS->>UQCS: updateAttendanceQuest(userQuestId, attendanceCheck, requirementCount)
        alt 어제 출석하지 않은 경우
            UQCS->>UQCS: updateQuestProgress(userQuestId, requirementCount, UserQuest::currentStreakZero)
        else 어제 출석한 경우
            UQCS->>UQCS: updateQuestProgress(userQuestId, requirementCount, UserQuest::currentStreakPlusOne)
        end
    else updateNewsQuest 호출
        UQCS->>UQCS: updateNewsQuest(userQuestId, newsHistoryCount, requirementCount)
        UQCS->>UQCS: updateQuestProgress(userQuestId, requirementCount,<br/>(uq) -> uq.updateProgressCount(requirementCount, newsHistoryCount))
    else updateQuizQuest 호출
        UQCS->>UQCS: updateQuizQuest(userQuestId, quizHistoryCount, requirementCount)
        UQCS->>UQCS: updateQuestProgress(userQuestId, requirementCount,<br/>(uq) -> uq.updateProgressCount(requirementCount, quizHistoryCount))
    else updateScrapQuest 호출
        UQCS->>UQCS: updateScrapQuest(userQuestId, scrapCount, requirementCount)
        UQCS->>UQCS: updateQuestProgress(userQuestId, requirementCount,<br/>(uq) -> uq.updateProgressCount(requirementCount, scrapCount))
    end

    UQCS->>+UQRepo: findById(userQuestId)
    alt userQuestId가 존재하지 않는 경우
        UQRepo-->>UQCS: Optional.empty()
        UQCS->>UQCS: throw new UserQuestNotFoundException(userQuestId)
    else userQuestId가 존재하는 경우
        UQRepo-->>-UQCS: UserQuest userQuest
    end

    UQCS->>UQCS: updater.accept(userQuest)
    Note over UQCS: Consumer<UserQuest> 함수형 인터페이스 실행

    alt ATTENDANCE 퀘스트 (연속일수 기반)
        UQCS->>+UserQuest: currentStreakZero() 또는 currentStreakPlusOne()
        UserQuest->>UserQuest: this.currentStreak = 0 또는 this.currentStreak += 1
        UserQuest-->>-UQCS: void
        UQCS->>UQCS: if (userQuest.getCurrentStreak() == requirementCount)
    else NEWS/QUIZ/SCRAP 퀘스트 (누적 카운트 기반)
        UQCS->>+UserQuest: updateProgressCount(requirementCount, count)
        UserQuest->>UserQuest: this.progressCount = Math.min(requirementCount, count)
        UserQuest-->>-UQCS: void
        UQCS->>UQCS: if (userQuest.getProgressCount() >= requirementCount)
    end

    alt 퀘스트 완료 조건 충족
        UQCS->>+UserQuest: completeQuest()
        UserQuest->>UserQuest: this.completed = true
        UserQuest-->>-UQCS: void
    end

    UQCS->>+UQRepo: save(userQuest)
    UQRepo-->>-UQCS: UserQuest updatedUserQuest

    UQCS->>UQCS: UserQuestDto.toDto(updatedUserQuest)
    UQCS->>UQCS: return UserQuestDto

    Note over UQCS: 완료 조건 상세<br/>• ATTENDANCE: currentStreak == requirementCount (연속 5일)<br/>• NEWS: progressCount >= requirementCount (누적 20개)<br/>• QUIZ: progressCount >= requirementCount (누적 25개)<br/>• SCRAP: progressCount >= requirementCount (누적 5개)

```
## 각 도메인별 활동 카운트 조회
``` mermaid
sequenceDiagram
    participant UpdateLogic as updateSingleQuest
    participant ARS as AttendanceReadService
    participant FNS as FindNewsService
    participant FUQZS as FindUserQuizService
    participant FSHS as FindScrapHistoryService
    participant AttRepo as AttendanceRepository
    participant NewsRepo as NewsHistoryRepository
    participant QuizRepo as QuizHistoryRepository
    participant ScrapRepo as ScrapHistoryRepository

    Note over UpdateLogic, ScrapRepo: 각 도메인별 활동 카운트 조회

    Note over UpdateLogic, AttRepo: 출석 서비스 - 어제 출석 체크
    UpdateLogic->>+ARS: wasAttendedYesterday(userId)
    Note over ARS: @Transactional(readOnly = true)

    ARS->>ARS: LocalDate yesterday = LocalDate.now().minusDays(1)
    ARS->>+AttRepo: existsByUserIdAndCheckDate(userId, yesterday)
    Note over AttRepo: SELECT COUNT(*) > 0 FROM attendance<br/>WHERE user_id = ? AND check_date = ?
    AttRepo-->>-ARS: boolean (어제 출석 여부)
    ARS-->>-UpdateLogic: attendanceCheck

    Note over UpdateLogic, NewsRepo: 뉴스 서비스 - 주간 읽기 카운트
    UpdateLogic->>+FNS: findNewsHistoryCountByUserId(userId)
    FNS->>FNS: LocalDate today = LocalDate.now()<br/>LocalDate thisWeekMonday = today.with(DayOfWeek.MONDAY)<br/>LocalDateTime start = thisWeekMonday.atStartOfDay()<br/>LocalDateTime end = LocalDateTime.now()
    FNS->>+NewsRepo: countByUserIdAndReadAtBetween(userId, start, end)
    Note over NewsRepo: SELECT COUNT(*) FROM news_read_history<br/>WHERE user_id = ? AND read_at BETWEEN ? AND ?
    NewsRepo-->>-FNS: int newsHistoryCount
    FNS-->>-UpdateLogic: newsHistoryCount

    Note over UpdateLogic, QuizRepo: 퀴즈 서비스 - 주간 정답 카운트
    UpdateLogic->>+FUQZS: findQuizHistoryCountByUserId(userId)
    FUQZS->>FUQZS: LocalDate today = LocalDate.now()<br/>LocalDate thisWeekMonday = today.with(DayOfWeek.MONDAY)<br/>LocalDateTime start = thisWeekMonday.atStartOfDay()<br/>LocalDateTime end = LocalDateTime.now()
    FUQZS->>+QuizRepo: countByUserIdAndAnsweredAtBetween(userId, start, end)
    Note over QuizRepo: SELECT COUNT(*) FROM quiz_history<br/>WHERE user_id = ? AND answered_at BETWEEN ? AND ?
    QuizRepo-->>-FUQZS: int quizHistoryCount
    FUQZS-->>-UpdateLogic: quizHistoryCount

    Note over UpdateLogic, ScrapRepo: 스크랩 서비스 - 주간 타입별 카운트
    alt SCRAP_NEWS 퀘스트
        UpdateLogic->>+FSHS: findScrapHistoryCountByUserId(userId, "NEWS")
        FSHS->>FSHS: 조건 확인 if(category.equals("NEWS"))
        FSHS->>FSHS: LocalDate today = LocalDate.now()<br/>LocalDate thisWeekMonday = today.with(DayOfWeek.MONDAY)<br/>LocalDateTime start = thisWeekMonday.atStartOfDay()<br/>LocalDateTime end = LocalDateTime.now()
        FSHS->>+ScrapRepo: countByUserIdAndTypeAndScrapAtBetween(userId, ScrapType.NEWS, start, end)
        Note over ScrapRepo: SELECT COUNT(*) FROM scrap_history<br/>WHERE user_id = ? AND type = 'NEWS'<br/>AND scrap_at BETWEEN ? AND ?
        ScrapRepo-->>-FSHS: int newsScrapCount
        FSHS-->>-UpdateLogic: newsScrapCount
    else SCRAP_QUIZ 퀘스트
        UpdateLogic->>+FSHS: findScrapHistoryCountByUserId(userId, "QUIZ")
        FSHS->>FSHS: else (category.equals("QUIZ"))
        FSHS->>FSHS: LocalDate today = LocalDate.now()<br/>LocalDate thisWeekMonday = today.with(DayOfWeek.MONDAY)<br/>LocalDateTime start = thisWeekMonday.atStartOfDay()<br/>LocalDateTime end = LocalDateTime.now()
        FSHS->>+ScrapRepo: countByUserIdAndTypeAndScrapAtBetween(userId, ScrapType.QUIZ, start, end)
        Note over ScrapRepo: SELECT COUNT(*) FROM scrap_history<br/>WHERE user_id = ? AND type = 'QUIZ'<br/>AND scrap_at BETWEEN ? AND ?
        ScrapRepo-->>-FSHS: int quizScrapCount
        FSHS-->>-UpdateLogic: quizScrapCount
    end

    Note over UpdateLogic: 공통 특징<br/>• 매주 월요일 00:00부터 현재 시점까지 집계<br/>• LocalDate.with(DayOfWeek.MONDAY) 사용<br/>• 시스템 기본 타임존 기준<br/>• 중복 저장 방지 & 실시간 COUNT로 정확도 보장

```

