### PR TITLE
금융 용어 사전 조회 API 구현

### DIFF
--- a/main-server/src/main/java/com/freedom/common/exception/ErrorCode.java
+++ b/main-server/src/main/java/com/freedom/common/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR("COMMON001", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     METHOD_NOT_ALLOWED("COMMON002", "허용되지 않은 HTTP 메서드입니다.", HttpStatus.METHOD_NOT_ALLOWED),
     API_NOT_FOUND("COMMON003", "요청하신 API 경로를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    RESOURCE_NOT_FOUND("COMMON004", "요청하신 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     
     // Validation 에러
     VALIDATION_ERROR("VALIDATION001", "", HttpStatus.BAD_REQUEST),

--- a/main-server/src/main/java/com/freedom/common/exception/GlobalExceptionHandler.java
+++ b/main-server/src/main/java/com/freedom/common/exception/GlobalExceptionHandler.java
@@ -304,6 +304,14 @@ public class GlobalExceptionHandler {
                 .body(ErrorResponse.of(ErrorCode.CHARACTER_NAME_DUPLICATE));
     }
 
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleResourceNotFoundException(ResourceNotFoundException e) {
+        log.warn("리소스를 찾을 수 없음: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.RESOURCE_NOT_FOUND.getStatus())
+                .body(ErrorResponse.of(ErrorCode.RESOURCE_NOT_FOUND, e.getMessage()));
+    }
+
     @ExceptionHandler(NewsScrapAlreadyExistsException.class)
     public ResponseEntity<ErrorResponse> handleNewsScrapAlreadyExistsException(NewsScrapAlreadyExistsException e) {
         log.warn("이미 스크랩한 뉴스: userId={}, newsArticleId={}", e.getUserId(), e.getNewsArticleId());

--- a/main-server/src/main/java/com/freedom/common/exception/custom/ResourceNotFoundException.java
+++ b/main-server/src/main/java/com/freedom/common/exception/custom/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.freedom.common.exception.custom;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/main-server/src/main/java/com/freedom/saving/term/api/FinancialTermController.java
+++ b/main-server/src/main/java/com/freedom/saving/term/api/FinancialTermController.java
@@ -1,0 +1,24 @@
+package com.freedom.saving.term.api;
+
+import com.freedom.saving.term.api.dto.TermResponseDto;
+import com.freedom.saving.term.application.FinancialTermService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/savings/terms")
+@RequiredArgsConstructor
+public class FinancialTermController {
+
+    private final FinancialTermService termService;
+
+    @GetMapping("/{termName}")
+    public ResponseEntity<TermResponseDto> getTerm(@PathVariable String termName) {
+        TermResponseDto responseDto = termService.findTerm(termName);
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/main-server/src/main/java/com/freedom/saving/term/api/dto/TermResponseDto.java
+++ b/main-server/src/main/java/com/freedom/saving/term/api/dto/TermResponseDto.java
@@ -1,0 +1,12 @@
+package com.freedom.saving.term.api.dto;
+
+/**
+ * 금융 용어 조회 API의 단건 응답 DTO
+ * @param term          용어 이름
+ * @param description   용어 설명
+ */
+public record TermResponseDto(
+        String term,
+        String description
+) {
+}

--- a/main-server/src/main/java/com/freedom/saving/term/application/FinancialTermService.java
+++ b/main-server/src/main/java/com/freedom/saving/term/application/FinancialTermService.java
@@ -1,0 +1,34 @@
+package com.freedom.saving.term.application;
+
+import com.freedom.common.exception.custom.ResourceNotFoundException;
+import com.freedom.saving.term.api.dto.TermResponseDto;
+import com.freedom.saving.term.domain.FinancialTermRepository;
+import com.freedom.saving.term.domain.TermAliasRepository;
+import com.freedom.saving.term.domain.entity.FinancialTerm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FinancialTermService {
+
+    private final FinancialTermRepository termRepository;
+    private final TermAliasRepository aliasRepository;
+
+    public TermResponseDto findTerm(String termName) {
+        return termRepository.findByTerm(termName)
+                .map(term -> new TermResponseDto(term.getTerm(), term.getDescription()))
+                .orElseGet(() -> findByAlias(termName));
+    }
+
+    private TermResponseDto findByAlias(String aliasName) {
+        return aliasRepository.findByAliasTerm(aliasName)
+                .map(alias -> {
+                    FinancialTerm originalTerm = alias.getFinancialTerm();
+                    return new TermResponseDto(originalTerm.getTerm(), originalTerm.getDescription());
+                })
+                .orElseThrow(() -> new ResourceNotFoundException("금융 용어를 찾을 수 없습니다: " + aliasName));
+    }
+}

--- a/main-server/src/main/java/com/freedom/saving/term/domain/FinancialTermRepository.java
+++ b/main-server/src/main/java/com/freedom/saving/term/domain/FinancialTermRepository.java
@@ -1,0 +1,11 @@
+package com.freedom.saving.term.domain;
+
+import com.freedom.saving.term.domain.entity.FinancialTerm;
+
+import java.util.Optional;
+
+// Port 인터페이스
+public interface FinancialTermRepository {
+
+    Optional<FinancialTerm> findByTerm(String term);
+}

--- a/main-server/src/main/java/com/freedom/saving/term/domain/TermAliasRepository.java
+++ b/main-server/src/main/java/com/freedom/saving/term/domain/TermAliasRepository.java
@@ -1,0 +1,11 @@
+package com.freedom.saving.term.domain;
+
+import com.freedom.saving.term.domain.entity.TermAlias;
+
+import java.util.Optional;
+
+// Port 인터페이스
+public interface TermAliasRepository {
+
+    Optional<TermAlias> findByAliasTerm(String aliasTerm);
+}

--- a/main-server/src/main/java/com/freedom/saving/term/domain/entity/FinancialTerm.java
+++ b/main-server/src/main/java/com/freedom/saving/term/domain/entity/FinancialTerm.java
@@ -1,0 +1,33 @@
+package com.freedom.saving.term.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 금융 용어의 대표 개념을 정의하는 엔티티
+ */
+@Getter
+@Entity
+@Table(name = "financial_terms")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FinancialTerm {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "term", nullable = false, unique = true, length = 100)
+    private String term; // 대표 용어
+
+    @Column(name = "description", columnDefinition = "TEXT", nullable = false)
+    private String description; // 용어 설명
+
+    @Builder
+    public FinancialTerm(String term, String description) {
+        this.term = term;
+        this.description = description;
+    }
+}

--- a/main-server/src/main/java/com/freedom/saving/term/domain/entity/TermAlias.java
+++ b/main-server/src/main/java/com/freedom/saving/term/domain/entity/TermAlias.java
@@ -1,0 +1,31 @@
+package com.freedom.saving.term.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "term_aliases")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TermAlias {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "alias_term", nullable = false, unique = true, length = 100)
+    private String aliasTerm;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "term_id", nullable = false)
+    private FinancialTerm financialTerm;
+
+    @Builder
+    public TermAlias(String aliasTerm) {
+        this.aliasTerm = aliasTerm;
+    }
+
+}

--- a/main-server/src/main/java/com/freedom/saving/term/infra/FinancialTermJpaRepository.java
+++ b/main-server/src/main/java/com/freedom/saving/term/infra/FinancialTermJpaRepository.java
@@ -1,0 +1,13 @@
+package com.freedom.saving.term.infra;
+
+import com.freedom.saving.term.domain.FinancialTermRepository;
+import com.freedom.saving.term.domain.entity.FinancialTerm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FinancialTermJpaRepository extends JpaRepository<FinancialTerm, Long>, FinancialTermRepository {
+
+    @Override
+    Optional<FinancialTerm> findByTerm(String term);
+}

--- a/main-server/src/main/java/com/freedom/saving/term/infra/TermAliasJpaRepository.java
+++ b/main-server/src/main/java/com/freedom/saving/term/infra/TermAliasJpaRepository.java
@@ -1,0 +1,13 @@
+package com.freedom.saving.term.infra;
+
+import com.freedom.saving.term.domain.TermAliasRepository;
+import com.freedom.saving.term.domain.entity.TermAlias;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TermAliasJpaRepository extends JpaRepository<TermAlias, Long>, TermAliasRepository {
+
+    @Override
+    Optional<TermAlias> findByAliasTerm(String aliasTerm);
+}


### PR DESCRIPTION
## Description
- 사용자가 앱 내에서 어려운 금융 용어를 터치했을 때, 그 의미를 바로 확인할 수 있는 금융 용어 사전 조회 API를 구현.
- 사용자가 동의어(예: '해약')를 요청하더라도, 내부적으로 원본 용어('중도 해지')를 찾아 그에 맞는 설명을 반환하는 로직을 포함.

## 구현 사항
- `GET /api/savings/terms/{termName}` 엔드포인트를 FinancialTermController에 추가하여 기능을 외부에 노출
- DTO: API 응답을 위한 TermResponseDto를 작성
