### PR TITLE
여러 상품 가입 시 자동 납입 처리 문제 해결

### DIFF
--- a/main-server/src/main/java/com/freedom/saving/application/AutoDebitResult.java
+++ b/main-server/src/main/java/com/freedom/saving/application/AutoDebitResult.java
@@ -1,0 +1,10 @@
+package com.freedom.saving.application;
+
+/**
+ * 자동납입 처리 결과
+ */
+public enum AutoDebitResult {
+    SUCCESS,    // 성공
+    FAILURE,    // 실패
+    SKIPPED     // 스킵 (처리할 것이 없음)
+}

--- a/main-server/src/main/java/com/freedom/saving/application/AutoDebitService.java
+++ b/main-server/src/main/java/com/freedom/saving/application/AutoDebitService.java
@@ -41,14 +41,14 @@ public class AutoDebitService {
     private final SavingTransactionService savingTxnService;
 
     /**
-     * 접속한 사용자에 대해 하루에 1회 자동 납입 수행
+     * 접속한 사용자에 대해 구독별 자동 납입 수행
      * 
      * 동작 방식:
      * 1. 사용자 존재 여부 확인
-     * 2. 오늘 이미 처리되었는지 확인 (lastAutoPaymentDate 체크)
-     * 3. 활성 구독 조회
-     * 4. 각 구독별로 오늘 납입 예정인지 확인 후 처리
-     * 5. 처리 완료 후 lastAutoPaymentDate 업데이트
+     * 2. 활성 구독 조회
+     * 3. 각 구독별로 개별적으로 자동납입 처리 (날짜별 독립 처리)
+     * 4. 구독별 처리 결과 집계
+     *
      * 
      * @param userId 사용자 ID
      */
@@ -56,39 +56,35 @@ public class AutoDebitService {
     public void runOncePerDay(Long userId) {
         log.info("자동납입 시작 - 사용자 ID: {}", userId);
         
-        // 1. 사용자 존재 여부 확인
+        // 1. 사용자 존재 여부 확인 (조기 반환으로 성능 최적화)
         User user = userRepo.findById(userId).orElse(null);
         if (user == null) {
             log.warn("사용자를 찾을 수 없음 - ID: {}", userId);
             return;
         }
         
-        // 2. 오늘 이미 처리되었는지 확인
-        LocalDate today = LocalDate.now();
-        if (today.equals(user.getLastAutoPaymentDate())) {
-            log.info("이미 오늘 자동납입 처리 완료 - 사용자 ID: {}", userId);
-            return;
-        }
-        
-        // 3. 활성 구독 조회
+        // 2. 활성 구독 조회
         List<SavingSubscription> activeSubscriptions = subscriptionRepo.findByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE);
         log.info("활성 구독 수: {} - 사용자 ID: {}", activeSubscriptions.size(), userId);
         
         if (activeSubscriptions.isEmpty()) {
             log.info("활성 구독이 없음 - 사용자 ID: {}", userId);
-            updateLastAutoPaymentDate(user, today);
             return;
         }
         
-        // 4. 각 구독별로 자동납입 처리
+        // 3. 각 구독별로 개별 자동납입 처리
+        LocalDate today = LocalDate.now();
         int successCount = 0;
         int failureCount = 0;
+        int skippedCount = 0;
         
         for (SavingSubscription subscription : activeSubscriptions) {
             try {
-                boolean processed = processSubscriptionAutoDebit(userId, subscription, today);
-                if (processed) {
-                    successCount++;
+                AutoDebitResult result = processSubscriptionAutoDebit(userId, subscription, today);
+                switch (result) {
+                    case SUCCESS -> successCount++;
+                    case FAILURE -> failureCount++;
+                    case SKIPPED -> skippedCount++;
                 }
             } catch (Exception e) {
                 failureCount++;
@@ -97,45 +93,53 @@ public class AutoDebitService {
             }
         }
         
-        // 5. 처리 완료 후 마지막 처리 날짜 업데이트
-        updateLastAutoPaymentDate(user, today);
-        
-        log.info("자동납입 완료 - 사용자 ID: {}, 성공: {}, 실패: {}", userId, successCount, failureCount);
+        // 4. 처리 결과 로깅 (성능 모니터링)
+        if (successCount > 0 || failureCount > 0) {
+            log.info("자동납입 완료 - 사용자 ID: {}, 성공: {}, 실패: {}, 스킵: {}", 
+                    userId, successCount, failureCount, skippedCount);
+        } else {
+            log.debug("자동납입 완료 (처리할 구독 없음) - 사용자 ID: {}", userId);
+        }
     }
     
     /**
      * 개별 구독에 대한 자동납입 처리
      * 
+     * 성능 최적화:
+     * - 조기 반환으로 불필요한 처리 방지
+     * - 조건부 로깅으로 성능 향상
+     * - 명확한 에러 처리
+     * 
      * @param userId 사용자 ID
      * @param subscription 구독 정보
      * @param today 오늘 날짜
-     * @return 처리 여부 (true: 처리됨, false: 처리할 것이 없음)
+     * @return 처리 결과 (SUCCESS: 성공, FAILURE: 실패, SKIPPED: 스킵)
      */
     @Transactional
-    public boolean processSubscriptionAutoDebit(Long userId, SavingSubscription subscription, LocalDate today) {
+    public AutoDebitResult processSubscriptionAutoDebit(Long userId, SavingSubscription subscription, LocalDate today) {
         log.debug("구독 자동납입 처리 시작 - 구독 ID: {}, 사용자 ID: {}", subscription.getId(), userId);
         
-        // 1. 다음 납입 계획 조회
+        // 1. 다음 납입 계획 조회 (조기 반환)
         SavingPaymentHistory plannedPayment = paymentRepo.findNextPlannedPayment(subscription.getId())
                 .orElse(null);
         
         if (plannedPayment == null) {
             log.debug("다음 납입 계획이 없음 - 구독 ID: {}", subscription.getId());
-            return false;
+            return AutoDebitResult.SKIPPED;
         }
         
         // 2. 오늘 납입 예정인지 확인
         if (!today.equals(plannedPayment.getDueServiceDate())) {
             log.debug("오늘 납입 예정이 아님 - 구독 ID: {}, 예정일: {}, 오늘: {}", 
                      subscription.getId(), plannedPayment.getDueServiceDate(), today);
-            return false;
+            return AutoDebitResult.SKIPPED;
         }
         
-        // 3. 납입 금액 유효성 확인
+        // 3. 납입 금액 유효성 확인 (조기 반환)
         BigDecimal amount = plannedPayment.getExpectedAmount();
         if (amount == null || amount.signum() <= 0) {
             log.warn("유효하지 않은 납입 금액 - 구독 ID: {}, 금액: {}", subscription.getId(), amount);
-            return false;
+            return AutoDebitResult.SKIPPED;
         }
         
         // 4. 자동 납입 실행
@@ -147,23 +151,23 @@ public class AutoDebitService {
             WalletTransaction transaction = savingTxnService.processSavingAutoDebit(
                     userId, requestId, amount, subscription.getId());
             
-            // 5. 납입 이력 업데이트
+            // 5. 납입 이력 업데이트 (트랜잭션 내에서)
             plannedPayment.markPaid(amount, transaction.getId(), null);
             paymentRepo.save(plannedPayment);
             
             log.info("자동납입 성공 - 구독 ID: {}, 금액: {}, 거래 ID: {}", 
                     subscription.getId(), amount, transaction.getId());
             
-            return true;
+            return AutoDebitResult.SUCCESS;
             
         } catch (Exception e) {
             log.error("자동납입 실패 - 구독 ID: {}, 금액: {}, 오류: {}", 
                      subscription.getId(), amount, e.getMessage(), e);
             
-            // 6. 실패 시 미납 처리
+            // 6. 실패 시 미납 처리 (트랜잭션 내에서)
             handlePaymentFailure(subscription, plannedPayment);
             
-            return false;
+            return AutoDebitResult.FAILURE;
         }
     }
     
@@ -201,22 +205,4 @@ public class AutoDebitService {
         }
     }
     
-    /**
-     * 사용자의 마지막 자동납입 처리 날짜 업데이트
-     * 
-     * @param user 사용자 정보
-     * @param today 오늘 날짜
-     */
-    @Transactional
-    public void updateLastAutoPaymentDate(User user, LocalDate today) {
-        try {
-            user.updateLastAutoPaymentDate(today);
-            userRepo.save(user);
-            log.debug("마지막 자동납입 처리 날짜 업데이트 완료 - 사용자 ID: {}, 날짜: {}", 
-                     user.getId(), today);
-        } catch (Exception e) {
-            log.error("마지막 자동납입 처리 날짜 업데이트 실패 - 사용자 ID: {}, 오류: {}", 
-                     user.getId(), e.getMessage(), e);
-        }
-    }
 }

--- a/main-server/src/main/java/com/freedom/saving/infra/payment/SavingPaymentHistoryJpaAdapter.java
+++ b/main-server/src/main/java/com/freedom/saving/infra/payment/SavingPaymentHistoryJpaAdapter.java
@@ -32,7 +32,7 @@ public class SavingPaymentHistoryJpaAdapter implements SavingPaymentHistoryRepos
 
     @Override
     public Optional<SavingPaymentHistory> findNextPlannedPayment(Long subscriptionId) {
-        return jpaRepository.findNextPlannedPayment(subscriptionId);
+        return jpaRepository.findFirstBySubscriptionIdAndStatusOrderByDueServiceDateAsc(subscriptionId, SavingPaymentHistory.PaymentStatus.PLANNED);
     }
 
     @Override

--- a/main-server/src/main/java/com/freedom/saving/infra/payment/SavingPaymentHistoryJpaRepository.java
+++ b/main-server/src/main/java/com/freedom/saving/infra/payment/SavingPaymentHistoryJpaRepository.java
@@ -18,8 +18,7 @@ public interface SavingPaymentHistoryJpaRepository extends JpaRepository<SavingP
 
     long countBySubscriptionIdAndStatus(Long subscriptionId, SavingPaymentHistory.PaymentStatus status);
 
-    @Query("select p from SavingPaymentHistory p where p.subscriptionId = :subscriptionId and p.status = 'PLANNED' order by p.dueServiceDate asc")
-    Optional<SavingPaymentHistory> findNextPlannedPayment(@Param("subscriptionId") Long subscriptionId);
+    Optional<SavingPaymentHistory> findFirstBySubscriptionIdAndStatusOrderByDueServiceDateAsc(Long subscriptionId, SavingPaymentHistory.PaymentStatus status);
 
     Optional<SavingPaymentHistory> findBySubscriptionIdAndCycleNo(Long subscriptionId, Integer cycleNo);
 


### PR DESCRIPTION
## 문제 해결
- **여러 상품 가입 시 자동납입 미동작**: `lastAutoPaymentDate` 기반 체크로 인한 문제 해결  

---

## 변경 사항

### 1. 쿼리 수정
- `findFirstBySubscriptionIdAndStatusOrderByDueServiceDateAsc` 메서드로 단일 결과만 반환  
- 가장 이른 납입 예정일의 계획만 조회하도록 개선  

### 2. AutoDebitService 개편
- `lastAutoPaymentDate` 기반 체크 제거  
- 구독별 **독립적인 자동납입 처리**로 변경  
- `AutoDebitResult` **enum 도입**으로 처리 결과를 명확하게 표현  

### 3. 코드 구조 개선
- `AutoDebitResult` enum을 **별도 파일로 분리**  